### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/smoke-test-pr.yaml
+++ b/.github/workflows/smoke-test-pr.yaml
@@ -14,11 +14,8 @@ concurrency:
 
 jobs:
   smoke_test_pr:
-
     runs-on: ubuntu-latest
-
     if: ${{ github.event.label.name == 'run smoke test' }}
-
     steps:
       - name: Get User Permission
         id: checkAccess

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -17,9 +17,7 @@ concurrency:
 
 jobs:
   smoke_test:
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Get User Permission
         id: checkAccess

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.1
+
+- fix build
+
 ## 0.1.0
 
 Initial commit.

--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -1,6 +1,6 @@
 """Cookidoo API package."""
 
-__version__ = "0.2.0-a0"
+__version__ = "0.1.1"
 
 from .const import (
     DEFAULT_COOKIDOO_CONFIG,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license = {text = "MIT License"}
 keywords = ["cookidoo", "todo", "web", "browser", "scaping", "home-assistant", "iot"]
 
 [tool.setuptools]
-packages = ["cookidoo_api"]
+packages = ["cookidoo_api", "cookidoo_api.actions", "cookidoo_api.jobs"]
 
 [tool.setuptools.package-data]
 cookidoo_api = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ keywords = ["cookidoo", "todo", "web", "browser", "scaping", "home-assistant", "
 
 [tool.setuptools]
 
+[tool.setuptools.packages.find]
+where = ["cookidoo_api"]
+include = ["*"]
+
 [tool.setuptools.package-data]
 cookidoo_api = ["py.typed"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,7 @@ keywords = ["cookidoo", "todo", "web", "browser", "scaping", "home-assistant", "
 [tool.setuptools]
 
 [tool.setuptools.packages.find]
-where = ["cookidoo_api"]
-include = ["*"]
+include = ["cookidoo_api*"]
 
 [tool.setuptools.package-data]
 cookidoo_api = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ keywords = ["cookidoo", "todo", "web", "browser", "scaping", "home-assistant", "
 
 [tool.setuptools]
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+where = ["cookidoo_api"]
 
 [tool.setuptools.package-data]
 cookidoo_api = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ keywords = ["cookidoo", "todo", "web", "browser", "scaping", "home-assistant", "
 
 [tool.setuptools]
 
-[tool.setuptools.packages.find]
-where = ["cookidoo_api"]
-
 [tool.setuptools.package-data]
 cookidoo_api = ["py.typed"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ license = {text = "MIT License"}
 keywords = ["cookidoo", "todo", "web", "browser", "scaping", "home-assistant", "iot"]
 
 [tool.setuptools]
-packages = ["cookidoo_api", "cookidoo_api.actions", "cookidoo_api.jobs"]
+
+[tool.setuptools.packages]
+find = {}
 
 [tool.setuptools.package-data]
 cookidoo_api = ["py.typed"]


### PR DESCRIPTION
The python package setup config did not consider the submodules, as it was hard coded to the top level package. We now take everything inside the `cookidoo_api` folder including any submodule.