### PR TITLE
Fix exotic domains

### DIFF
--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -22,6 +22,7 @@ jobs:
           - ch
           - de
           - pl
+          - ma
     steps:
       - name: Get User Permission
         id: checkAccess
@@ -66,6 +67,7 @@ jobs:
           EMAIL_CH: ${{ vars.EMAIL_CH }}
           EMAIL_DE: ${{ vars.EMAIL_DE }}
           EMAIL_PL: ${{ vars.EMAIL_PL }}
+          EMAIL_MA: ${{ vars.EMAIL_MA }}
           PASSWORD: ${{ secrets.PASSWORD }}
       # !!!!!!!!!!!!!!!!!!!!
       # From here on, we run new code which does not have access to the password, only the token
@@ -82,5 +84,6 @@ jobs:
           EMAIL_CH: ${{ vars.EMAIL_CH }}
           EMAIL_DE: ${{ vars.EMAIL_DE }}
           EMAIL_PL: ${{ vars.EMAIL_PL }}
+          EMAIL_MA: ${{ vars.EMAIL_MA }}
           PASSWORD: <redacted>
           

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -24,6 +24,7 @@ jobs:
           - ch
           - de
           - pl
+          - ma
     steps:
       - name: Get User Permission
         id: checkAccess
@@ -68,4 +69,5 @@ jobs:
           EMAIL_CH: ${{ vars.EMAIL_CH }}
           EMAIL_DE: ${{ vars.EMAIL_DE }}
           EMAIL_PL: ${{ vars.EMAIL_PL }}
+          EMAIL_MA: ${{ vars.EMAIL_MA }}
           PASSWORD: ${{ secrets.PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.11.2
+
+- Fix exotic countries which do share a common domain
+
 ## 0.11.1
 
 - Extend smoke tests to multiple accounts with different countries

--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -1,6 +1,6 @@
 """Cookidoo API package."""
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 from .cookidoo import Cookidoo
 from .exceptions import (

--- a/cookidoo_api/const.py
+++ b/cookidoo_api/const.py
@@ -20,6 +20,8 @@ DEFAULT_API_HEADERS: Final = {
 AUTHORIZATION_HEADER: Final = "{type} {access_token}"
 COOKIE_HEADER: Final = "v-token={access_token}"
 
+INTERNATIONAL_COUNTRY_CODE: Final = "xp"
+
 API_ENDPOINT: Final = "https://{country_code}.tmmobile.vorwerk-digital.com"
 TOKEN_PATH: Final = "ciam/auth/token"
 RECIPE_PATH: Final = "recipes/recipe/{language}/{id}"

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -28,6 +28,7 @@ from cookidoo_api.const import (
     EDIT_OWNERSHIP_ADDITIONAL_ITEMS_PATH,
     EDIT_OWNERSHIP_INGREDIENT_ITEMS_PATH,
     INGREDIENT_ITEMS_PATH,
+    INTERNATIONAL_COUNTRY_CODE,
     MANAGED_COLLECTIONS_PATH,
     RECIPE_PATH,
     REMOVE_ADDITIONAL_ITEMS_PATH,
@@ -142,6 +143,8 @@ class Cookidoo:
     @property
     def api_endpoint(self) -> URL:
         """Get the api endpoint."""
+        if "international" in self._cfg.localization.url:
+            return URL(API_ENDPOINT.format(country_code=INTERNATIONAL_COUNTRY_CODE))
         return URL(API_ENDPOINT.format(**self._cfg.localization.__dict__))
 
     async def refresh_token(self) -> CookidooAuthResponse:

--- a/docs/raw-api-requests/login.txt
+++ b/docs/raw-api-requests/login.txt
@@ -30,4 +30,4 @@ via: 1.1 6efc112ba7faf702bfdea07c3f51a870.cloudfront.net (CloudFront)
 x-amz-cf-pop: ZRH55-P2
 x-amz-cf-id: zcn9rZjMrb8aVSV862y0Zzqrh9c6XFhh9YJIIkQmL4CSN-dsf1rFNg==
 
-{"access_token":"eyJhbGci<redacted>","expires_in":43199,"id_token":"eyJhbGciOiJSUzI1NiIsIm<redacted>","iss":"https://eu.login.vorwerk.com/","jti":"4b027df7-8578-4cda-831f-d1fcb3ec77ad","refresh_token":"eyJhbGciOiJSUzI1NiI<redacted>","scope":"marcossapi openid profile email Online offline_access","token_type":"bearer","sub":"sub_uuid""}
+{"access_token":"eyJhbGci<redacted>","expires_in":43199,"id_token":"eyJhbGciOiJSUzI1NiIsIm<redacted>","iss":"https://eu.login.vorwerk.com/","jti":"4b027df7-8578-4cda-831f-d1fcb3ec77ad","refresh_token":"eyJhbGciOiJSUzI1NiI<redacted>","scope":"marcossapi openid profile email Online offline_access","token_type":"bearer","sub":"sub_uuid"}

--- a/example.py
+++ b/example.py
@@ -15,7 +15,7 @@ from cookidoo_api.helpers import (
     get_language_options,
     get_localization_options,
 )
-from cookidoo_api.types import CookidooConfig, CookidooLocalizationConfig
+from cookidoo_api.types import CookidooConfig
 
 load_dotenv()
 
@@ -44,9 +44,9 @@ async def main():
             cfg=CookidooConfig(
                 email=os.environ["EMAIL"],
                 password=os.environ["PASSWORD"],
-                localization=CookidooLocalizationConfig(
-                    country_code="ch", language="de-CH"
-                ),
+                localization=(
+                    await get_localization_options(country="ma", language="en")
+                )[0],
             ),
         )
         # Login


### PR DESCRIPTION
All countries which do not have a dedicated domain, share the international domain (`cookidoo.international`). This translates for the app to `xp.tmmobile.vorwerk-digital.com`.

Also, the smoke test has been extended with a respective country (malta).

--> Found here: https://github.com/home-assistant/core/issues/134583