### PR TITLE
Use the sub uuid for auth request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.12.0
+
+- Use sub from jwt as username no longer available at login stage
+
 ## 0.11.2
 
 - Fix exotic countries which do share a common domain

--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -1,6 +1,6 @@
 """Cookidoo API package."""
 
-__version__ = "0.11.2"
+__version__ = "0.12.0"
 
 from .cookidoo import Cookidoo
 from .exceptions import (

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -46,7 +46,7 @@ def cookidoo_auth_data_from_json(
 ) -> CookidooAuthResponse:
     """Convert a auth data received from the API to a cookidoo auth data."""
     return CookidooAuthResponse(
-        username=auth_data["sub"],
+        sub=auth_data["sub"],
         access_token=auth_data["access_token"],
         refresh_token=auth_data["refresh_token"],
         token_type=auth_data["token_type"],

--- a/cookidoo_api/types.py
+++ b/cookidoo_api/types.py
@@ -42,7 +42,7 @@ class CookidooAuthResponse:
     refresh_token: str
     token_type: str
     expires_in: int
-    username: str | None = None
+    sub: str
 
 
 @dataclass


### PR DESCRIPTION
Previously, the username was available and used, but this now cleans up the swap to a uuid/sub from the jwt.