### PR TITLE
Add a fix for the .co.uk countries which share a common domain

### DIFF
--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -23,6 +23,7 @@ jobs:
           - de
           - pl
           - ma
+          - ie
     steps:
       - name: Get User Permission
         id: checkAccess
@@ -68,6 +69,7 @@ jobs:
           EMAIL_DE: ${{ vars.EMAIL_DE }}
           EMAIL_PL: ${{ vars.EMAIL_PL }}
           EMAIL_MA: ${{ vars.EMAIL_MA }}
+          EMAIL_IE: ${{ vars.EMAIL_IE }}
           PASSWORD: ${{ secrets.PASSWORD }}
       # !!!!!!!!!!!!!!!!!!!!
       # From here on, we run new code which does not have access to the password, only the token
@@ -85,5 +87,6 @@ jobs:
           EMAIL_DE: ${{ vars.EMAIL_DE }}
           EMAIL_PL: ${{ vars.EMAIL_PL }}
           EMAIL_MA: ${{ vars.EMAIL_MA }}
+          EMAIL_IE: ${{ vars.EMAIL_IE }}
           PASSWORD: <redacted>
           

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -25,6 +25,7 @@ jobs:
           - de
           - pl
           - ma
+          - ie
     steps:
       - name: Get User Permission
         id: checkAccess
@@ -70,4 +71,5 @@ jobs:
           EMAIL_DE: ${{ vars.EMAIL_DE }}
           EMAIL_PL: ${{ vars.EMAIL_PL }}
           EMAIL_MA: ${{ vars.EMAIL_MA }}
+          EMAIL_IE: ${{ vars.EMAIL_IE }}
           PASSWORD: ${{ secrets.PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.12.2
+
+- Fix .co.uk countries which do share a common domain
+
 ## 0.12.1
 
 - Add support for recipes which feature ranges for quantity in addition to fixed values

--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -1,6 +1,6 @@
 """Cookidoo API package."""
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 from .cookidoo import Cookidoo
 from .exceptions import (

--- a/cookidoo_api/const.py
+++ b/cookidoo_api/const.py
@@ -21,6 +21,7 @@ AUTHORIZATION_HEADER: Final = "{type} {access_token}"
 COOKIE_HEADER: Final = "v-token={access_token}"
 
 INTERNATIONAL_COUNTRY_CODE: Final = "xp"
+CO_UK_COUNTRY_CODE: Final = "gb"
 
 API_ENDPOINT: Final = "https://{country_code}.tmmobile.vorwerk-digital.com"
 TOKEN_PATH: Final = "ciam/auth/token"

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -19,6 +19,7 @@ from cookidoo_api.const import (
     ADDITIONAL_ITEMS_PATH,
     API_ENDPOINT,
     AUTHORIZATION_HEADER,
+    CO_UK_COUNTRY_CODE,
     COMMUNITY_PROFILE_PATH,
     COOKIDOO_CLIENT_ID,
     CUSTOM_COLLECTIONS_PATH,
@@ -145,6 +146,8 @@ class Cookidoo:
         """Get the api endpoint."""
         if "international" in self._cfg.localization.url:
             return URL(API_ENDPOINT.format(country_code=INTERNATIONAL_COUNTRY_CODE))
+        if "co.uk" in self._cfg.localization.url:
+            return URL(API_ENDPOINT.format(country_code=CO_UK_COUNTRY_CODE))
         return URL(API_ENDPOINT.format(**self._cfg.localization.__dict__))
 
     async def refresh_token(self) -> CookidooAuthResponse:

--- a/example.py
+++ b/example.py
@@ -49,7 +49,7 @@ async def main():
                 email=os.environ["EMAIL"],
                 password=os.environ["PASSWORD"],
                 localization=(
-                    await get_localization_options(country="ma", language="en")
+                    await get_localization_options(country="ie", language="en-GB")
                 )[0],
             ),
         )

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -55,6 +55,8 @@ class TestGetterSetter:
             ("ch", "de-CH", "ch"),
             ("de", "de-DE", "de"),
             ("ma", "en", "xp"),
+            ("ie", "en-GB", "gb"),
+            ("gb", "en-GB", "gb"),
         ],
     )
     async def test_api_endpoint(


### PR DESCRIPTION
There is another group of .co.uk countries

- Ireland
- United Kingdom

which use the `gb` domain for the API endpoint.