### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
-requires = [
-  "setuptools>=46.4.0",
-  "wheel"
-]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -20,14 +17,13 @@ requires-python = ">=3.12"
 
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Intended Audience :: Information Technology",
   "Topic :: System :: Monitoring",
   "Topic :: System :: Logging",
   "Topic :: System :: Systems Administration",
 ]
-license = {text = "MIT License"}
+license = "MIT"
 keywords = ["cookidoo", "todo", "home-assistant", "iot"]
 
 [tool.setuptools]
@@ -191,7 +187,7 @@ max-complexity = 25
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-testpaths = [ 
+testpaths = [
     "tests",
 ]
 log_cli = true


### PR DESCRIPTION
Setuptools `v77` added full support for PEP 639 license expressions. Also remove `wheel` as build dependency. Setuptools doesn't use it anymore.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files