### PR TITLE
feat: add nutrition information support to recipe details

### DIFF
--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -36,7 +36,10 @@ from cookidoo_api.types import (
     CookidooIngredient,
     CookidooIngredientItem,
     CookidooLocalizationConfig,
+    CookidooNutrition,
+    CookidooNutritionGroup,
     CookidooRecipeCollection,
+    CookidooRecipeNutrition,
     CookidooShoppingRecipe,
     CookidooShoppingRecipeDetails,
     CookidooSubscription,
@@ -184,6 +187,27 @@ def cookidoo_recipe_details_from_json(
             for time_ in recipe["times"]
             if time_["type"] == "totalTime" and time_["quantity"]["value"]
         ),
+        nutrition_groups=[
+            CookidooNutritionGroup(
+                name=ng["name"],
+                recipe_nutritions=[
+                    CookidooRecipeNutrition(
+                        nutritions=[
+                            CookidooNutrition(
+                                number=n["number"],
+                                type=n["type"],
+                                unittype=n["unittype"],
+                            )
+                            for n in rn["nutritions"]
+                        ],
+                        quantity=rn["quantity"],
+                        unit_notation=rn["unitNotation"],
+                    )
+                    for rn in ng["recipeNutritions"]
+                ],
+            )
+            for ng in recipe.get("nutritionGroups", [])
+        ],
     )
 
 

--- a/cookidoo_api/raw_types.py
+++ b/cookidoo_api/raw_types.py
@@ -151,6 +151,29 @@ class RecipeDetailsTimeJSON(TypedDict):
     comment: str
 
 
+class RecipeDetailsNutritionJSON(TypedDict):
+    """The json for a recipe nutrition in the API."""
+
+    number: float
+    type: str
+    unittype: str
+
+
+class RecipeDetailsRecipeNutritionJSON(TypedDict):
+    """The json for a recipe nutrition item in the API."""
+
+    nutritions: list[RecipeDetailsNutritionJSON]
+    quantity: int
+    unitNotation: str
+
+
+class RecipeDetailsNutritionGroupJSON(TypedDict):
+    """The json for a recipe nutrition group in the API."""
+
+    name: str
+    recipeNutritions: list[RecipeDetailsRecipeNutritionJSON]
+
+
 class RecipeDetailsJSON(TypedDict):
     """The json for a recipe details in the API."""
 
@@ -165,6 +188,7 @@ class RecipeDetailsJSON(TypedDict):
     recipeUtensils: list[RecipeDetailsUtensilsJSON]
     servingSize: RecipeDetailsServingSizeJSON
     times: list[RecipeDetailsTimeJSON]
+    nutritionGroups: list[RecipeDetailsNutritionGroupJSON]
 
 
 class CustomRecipeYieldJSON(TypedDict):

--- a/cookidoo_api/types.py
+++ b/cookidoo_api/types.py
@@ -188,6 +188,63 @@ class CookidooRecipeCollection:
 
 
 @dataclass
+class CookidooNutrition:
+    """Nutrition value type.
+
+    Attributes
+    ----------
+    number
+        The value of the nutrition
+    type
+        The type of nutrition (e.g., protein, fat, kcal, etc.)
+    unittype
+        The unit of the nutrition value (e.g., g, kcal, kJ)
+
+    """
+
+    number: float
+    type: str
+    unittype: str
+
+
+@dataclass
+class CookidooRecipeNutrition:
+    """Recipe nutrition type.
+
+    Attributes
+    ----------
+    nutritions
+        List of nutrition values
+    quantity
+        The quantity for which the nutrition applies
+    unit_notation
+        The unit notation (e.g., 'ración')
+
+    """
+
+    nutritions: list[CookidooNutrition]
+    quantity: int
+    unit_notation: str
+
+
+@dataclass
+class CookidooNutritionGroup:
+    """Nutrition group type.
+
+    Attributes
+    ----------
+    name
+        The name of the nutrition group
+    recipe_nutritions
+        List of recipe nutrition objects
+
+    """
+
+    name: str
+    recipe_nutritions: list[CookidooRecipeNutrition]
+
+
+@dataclass
 class CookidooShoppingRecipeDetails(CookidooShoppingRecipe):
     """Cookidoo recipe details type.
 
@@ -209,6 +266,8 @@ class CookidooShoppingRecipeDetails(CookidooShoppingRecipe):
         The time needed preparing the recipe [in seconds]
     total_time
         The time needed until the recipe is ready [in seconds]
+    nutrition_groups
+        The nutrition groups of the recipe (from API, may be empty)
 
     """
 
@@ -220,6 +279,7 @@ class CookidooShoppingRecipeDetails(CookidooShoppingRecipe):
     serving_size: int
     active_time: int
     total_time: int
+    nutrition_groups: list[CookidooNutritionGroup]
 
 
 @dataclass


### PR DESCRIPTION
### Summary
This PR adds support for extracting nutritional information from recipe details returned by the Cookidoo API. 

### Changes Made

#### New Types Added (`types.py`)
- **`CookidooNutrition`**: Represents individual nutrition values (e.g., calories, protein)
  - `number`: The numeric value
  - `type`: The nutrition type (e.g., "protein", "fat", "kcal")
  - `unittype`: The unit of measurement (e.g., "g", "kcal", "kJ")

- **`CookidooRecipeNutrition`**: Groups nutrition values with their serving information
  - `nutritions`: List of `CookidooNutrition` objects
  - `quantity`: The quantity for which the nutrition applies
  - `unit_notation`: The unit notation (e.g., "ración", "serving")

- **`CookidooNutritionGroup`**: Organizes recipe nutritions into groups
  - `name`: Name of the nutrition group
  - `recipe_nutritions`: List of `CookidooRecipeNutrition` objects

- Updated `CookidooShoppingRecipeDetails` to include `nutrition_groups` field

#### Raw Type Definitions (`raw_types.py`)
- Added `RecipeDetailsNutritionJSON`: TypedDict for individual nutrition values
- Added `RecipeDetailsRecipeNutritionJSON`: TypedDict for recipe nutrition items
- Added `RecipeDetailsNutritionGroupJSON`: TypedDict for nutrition groups
- Updated `RecipeDetailsJSON` to include `nutritionGroups` field

#### Parsing Logic (`helpers.py`)
- Enhanced `cookidoo_recipe_details_from_json()` to parse nutrition data from API responses
- Follows existing code patterns and conventions

### Testing
- ✅ All unit tests passing (216/216)
- ✅ Smoke tests passing (9/11, expected failures unrelated to this change)
- ✅ All pre-commit hooks passing:
  - Ruff (linting)
  - Ruff-format (code formatting)
  - Mypy (type checking)
  - Markdownlint

### Backwards Compatibility
This is a **non-breaking change**. The new `nutrition_groups` field is added to the existing `CookidooShoppingRecipeDetails` type and will return an empty list if no nutrition data is available from the API.
