### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/miaucl/cookidoo-api/security/code-scanning/14](https://github.com/miaucl/cookidoo-api/security/code-scanning/14)

To fix the problem, set an explicit `permissions` block for the jobs that currently lack one, especially the `build` job. As a starting point, use `contents: read`, which allows the job to read repository contents but not to modify anything. This adheres to least privilege principles and satisfies CodeQL and security requirements. The change should be made to the `build` job definition, for example, on line 11, add:

```yaml
permissions:
  contents: read
```

No additional dependencies or methods are required; only a YAML edit in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
