### PR TITLE
Add recipe search API with result types and tests

### DIFF
--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -25,10 +25,13 @@ from .types import (
     CookidooItem,
     CookidooLocalizationConfig,
     CookidooRecipeCollection,
+    CookidooSearchRecipeHit,
+    CookidooSearchResult,
     CookidooShoppingRecipe,
     CookidooShoppingRecipeDetails,
     CookidooSubscription,
     CookidooUserInfo,
+    ThermomixMachineType,
 )
 
 __all__ = [
@@ -49,6 +52,8 @@ __all__ = [
     "CookidooChapter",
     "CookidooChapterRecipe",
     "CookidooRecipeCollection",
+    "CookidooSearchRecipeHit",
+    "CookidooSearchResult",
     "CookidooIngredient",
     "CookidooCollection",
     "CookidooException",
@@ -58,4 +63,5 @@ __all__ = [
     "CookidooRequestException",
     "CookidooResponseException",
     "CookidooUnavailableException",
+    "ThermomixMachineType",
 ]

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -65,6 +65,7 @@ from cookidoo_api.helpers import (
     cookidoo_ingredient_item_from_json,
     cookidoo_recipe_details_from_json,
     cookidoo_recipe_from_json,
+    cookidoo_search_result_from_json,
     cookidoo_subscription_from_json,
     cookidoo_user_info_from_json,
 )
@@ -86,13 +87,38 @@ from cookidoo_api.types import (
     CookidooCustomRecipe,
     CookidooIngredientItem,
     CookidooLocalizationConfig,
+    CookidooSearchResult,
     CookidooShoppingRecipe,
     CookidooShoppingRecipeDetails,
     CookidooSubscription,
     CookidooUserInfo,
+    ThermomixMachineType,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _normalize_list_param(value: str | list[str] | None) -> str | None:
+    """Normalize list/string params to comma-separated string."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return ",".join([v for v in value if v])
+    return value
+
+
+def _normalize_tmv_param(
+    value: ThermomixMachineType | str | list[ThermomixMachineType | str] | None,
+) -> str | None:
+    """Normalize TMV param to comma-separated string."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        normalized: list[str] = []
+        for item in value:
+            normalized.append(item.value if isinstance(item, ThermomixMachineType) else str(item))
+        return ",".join([v for v in normalized if v])
+    return value.value if isinstance(value, ThermomixMachineType) else value
 
 
 class Cookidoo:
@@ -139,6 +165,80 @@ class Cookidoo:
         """
         parsed = urlparse(self._cfg.localization.url)
         return URL(f"{parsed.scheme}://{parsed.netloc}")
+
+    async def _request(
+        self,
+        method: str,
+        url: URL,
+        operation: str,
+        *,
+        json: dict | list | None = None,
+        headers: dict[str, str] | None = None,
+        accepted_statuses: tuple[HTTPStatus, ...] = (HTTPStatus.OK,),
+    ) -> dict | None:
+        """Execute an HTTP request with standard error handling."""
+        merged_headers = {**self._api_headers, **(headers or {})}
+
+        try:
+            async with self._session.request(
+                method, url, headers=merged_headers, json=json
+            ) as r:
+                _LOGGER.debug(
+                    "Response from %s [%s]: %s", url, r.status, await r.text()
+                )
+
+                if r.status == HTTPStatus.UNAUTHORIZED:
+                    try:
+                        errmsg = await r.json()
+                    except (JSONDecodeError, ClientError):
+                        _LOGGER.debug(
+                            "Exception: Cannot parse request response:\n %s",
+                            traceback.format_exc(),
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "Exception: Cannot %s: %s",
+                            operation,
+                            errmsg.get("error_description", ""),
+                        )
+                    raise CookidooAuthException(
+                        f"{operation.capitalize()} failed due to authorization failure, "
+                        "the authorization token is invalid or expired."
+                    )
+
+                if r.status not in accepted_statuses:
+                    r.raise_for_status()
+
+                if r.status == HTTPStatus.NO_CONTENT:
+                    return None
+                try:
+                    return await r.json()  # type: ignore[return-value]
+                except (JSONDecodeError, KeyError) as e:
+                    _LOGGER.debug(
+                        "Exception: Cannot parse %s response:\n%s",
+                        operation,
+                        traceback.format_exc(),
+                    )
+                    raise CookidooParseException(
+                        f"{operation.capitalize()} failed during parsing of request response."
+                    ) from e
+
+        except (CookidooAuthException, CookidooRequestException, CookidooParseException):
+            raise
+        except TimeoutError as e:
+            _LOGGER.debug(
+                "Exception: Cannot %s:\n%s", operation, traceback.format_exc()
+            )
+            raise CookidooRequestException(
+                f"{operation.capitalize()} failed due to connection timeout."
+            ) from e
+        except ClientError as e:
+            _LOGGER.debug(
+                "Exception: Cannot %s:\n%s", operation, traceback.format_exc()
+            )
+            raise CookidooRequestException(
+                f"{operation.capitalize()} failed due to request exception."
+            ) from e
 
     async def login(self) -> None:
         """Perform browser-based OAuth2 login.
@@ -552,6 +652,128 @@ class Cookidoo:
             raise CookidooRequestException(
                 "Loading recipe details failed due to request exception."
             ) from e
+
+    async def search_recipes(
+        self,
+        query: str,
+        locale: str | None = None,
+        accessories: str | list[str] | None = None,
+        languages: str | list[str] | None = None,
+        categories: str | list[str] | None = None,
+        countries: str | list[str] | None = None,
+        ingredients: str | list[str] | None = None,
+        exclude_ingredients: str | list[str] | None = None,
+        tags: str | list[str] | None = None,
+        ratings: str | list[str] | None = None,
+        difficulty: str | None = None,
+        preparation_time: int | None = None,
+        total_time: int | None = None,
+        portions: int | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+        tmv: ThermomixMachineType | str | list[ThermomixMachineType | str] | None = None,
+    ) -> CookidooSearchResult:
+        """Search recipes in Cookidoo (GET).
+
+        Uses the same API base as the rest of the client (api_endpoint):
+        {api_endpoint}/search/{locale}
+
+        Parameters
+        ----------
+        query
+            Search query (e.g. "chicken", "pasta").
+        locale
+            Locale for the search path (e.g. "es", "en", "de").
+            Defaults to the first part of the configured language (e.g. "de-CH" -> "de").
+        accessories
+            Optional comma-separated accessory filters
+            (e.g. "includingFriend,includingBladeCover,includingBladeCoverWithPeeler,includingCutter,includingSensor").
+        languages
+            Optional comma-separated language codes (e.g. "en,es").
+        categories
+            Optional comma-separated category IDs.
+        countries
+            Optional comma-separated country codes (e.g. "ar").
+        ingredients
+            Optional comma-separated ingredients.
+        exclude_ingredients
+            Optional comma-separated excluded ingredients.
+        tags
+            Optional comma-separated tags.
+        ratings
+            Optional comma-separated ratings (e.g. "5,4").
+        difficulty
+            Optional difficulty (e.g. "easy", "medium", "hard").
+        preparation_time
+            Optional preparation time in seconds.
+        total_time
+            Optional total time in seconds.
+        portions
+            Optional portions count.
+        page
+            Optional page number (API-dependent, often 0- or 1-based).
+        page_size
+            Optional page size (API-dependent; common keys: pageSize).
+        tmv
+            Optional Thermomix machine version. Use ``ThermomixMachineType``
+            (e.g. ``ThermomixMachineType.TM7``) or a string ("TM7", "TM6", "TM5").
+
+        Returns
+        -------
+        CookidooSearchResult
+            Search result with recipes and total count.
+
+        Raises
+        ------
+        CookidooAuthException
+            When the access token is not valid anymore.
+        CookidooRequestException
+            If the request fails.
+        CookidooParseException
+            If the parsing of the request response fails.
+
+        """
+        if locale is None:
+            locale = self._cfg.localization.language.split("-")[0]
+        url = self.api_endpoint / "search" / locale
+        params: dict[str, str] = {"query": query}
+        if accessories is not None:
+            params["accessories"] = _normalize_list_param(accessories)
+        if languages is not None:
+            params["languages"] = _normalize_list_param(languages)
+        if categories is not None:
+            params["categories"] = _normalize_list_param(categories)
+        if countries is not None:
+            params["countries"] = _normalize_list_param(countries)
+        if ingredients is not None:
+            params["ingredients"] = _normalize_list_param(ingredients)
+        if exclude_ingredients is not None:
+            params["excludeIngredients"] = _normalize_list_param(exclude_ingredients)
+        if tags is not None:
+            params["tags"] = _normalize_list_param(tags)
+        if ratings is not None:
+            params["ratings"] = _normalize_list_param(ratings)
+        if difficulty is not None:
+            params["difficulty"] = difficulty
+        if preparation_time is not None:
+            params["preparationTime"] = str(preparation_time)
+        if total_time is not None:
+            params["totalTime"] = str(total_time)
+        if portions is not None:
+            params["portions"] = str(portions)
+        if page is not None:
+            params["page"] = str(page)
+        if page_size is not None:
+            params["pageSize"] = str(page_size)
+        if tmv is not None:
+            params["tmv"] = _normalize_tmv_param(tmv)
+        url = url.with_query(params)
+        result = await self._request(
+            "get", url, "search recipes", accepted_statuses=(HTTPStatus.OK,)
+        )
+        if result is None:
+            return CookidooSearchResult(recipes=[], total=0)
+        return cookidoo_search_result_from_json(result, self._cfg.localization)
 
     async def get_custom_recipe(self, id: str) -> CookidooCustomRecipe:
         """Get custom recipe.
@@ -3204,3 +3426,4 @@ class Cookidoo:
             raise CookidooRequestException(
                 "Remove custom recipe from calendar failed due to request exception."
             ) from e
+

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import re
 import time
 import traceback
-from typing import cast
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from aiohttp import ClientError, ClientSession
@@ -58,8 +58,6 @@ from cookidoo_api.exceptions import (
     CookidooRequestException,
 )
 from cookidoo_api.helpers import (
-    normalize_list_param,
-    normalize_tmv_param,
     cookidoo_additional_item_from_json,
     cookidoo_calendar_day_from_json,
     cookidoo_collection_from_json,
@@ -70,6 +68,8 @@ from cookidoo_api.helpers import (
     cookidoo_search_result_from_json,
     cookidoo_subscription_from_json,
     cookidoo_user_info_from_json,
+    normalize_list_param,
+    normalize_tmv_param,
 )
 from cookidoo_api.raw_types import (
     AdditionalItemJSON,
@@ -151,10 +151,10 @@ class Cookidoo:
         url: URL,
         operation: str,
         *,
-        json: dict | list | None = None,
+        json: dict[str, Any] | list[Any] | None = None,
         headers: dict[str, str] | None = None,
         accepted_statuses: tuple[HTTPStatus, ...] = (HTTPStatus.OK,),
-    ) -> dict | None:
+    ) -> dict[str, Any] | None:
         """Execute an HTTP request with standard error handling."""
         merged_headers = {**self._api_headers, **(headers or {})}
 
@@ -180,10 +180,7 @@ class Cookidoo:
                             operation,
                             errmsg.get("error_description", ""),
                         )
-                    raise CookidooAuthException(
-                        f"{operation.capitalize()} failed due to authorization failure, "
-                        "the authorization token is invalid or expired."
-                    )
+                    self._raise_auth_exception(operation)
 
                 if r.status not in accepted_statuses:
                     r.raise_for_status()
@@ -191,7 +188,7 @@ class Cookidoo:
                 if r.status == HTTPStatus.NO_CONTENT:
                     return None
                 try:
-                    return await r.json()  # type: ignore[return-value]
+                    return cast(dict[str, Any], await r.json())
                 except (JSONDecodeError, KeyError) as e:
                     _LOGGER.debug(
                         "Exception: Cannot parse %s response:\n%s",
@@ -202,7 +199,11 @@ class Cookidoo:
                         f"{operation.capitalize()} failed during parsing of request response."
                     ) from e
 
-        except (CookidooAuthException, CookidooRequestException, CookidooParseException):
+        except (
+            CookidooAuthException,
+            CookidooRequestException,
+            CookidooParseException,
+        ):
             raise
         except TimeoutError as e:
             _LOGGER.debug(
@@ -218,6 +219,14 @@ class Cookidoo:
             raise CookidooRequestException(
                 f"{operation.capitalize()} failed due to request exception."
             ) from e
+
+    @staticmethod
+    def _raise_auth_exception(operation: str) -> None:
+        """Raise the standard auth exception for request helpers."""
+        raise CookidooAuthException(
+            f"{operation.capitalize()} failed due to authorization failure, "
+            "the authorization token is invalid or expired."
+        )
 
     async def login(self) -> None:
         """Perform browser-based OAuth2 login.
@@ -650,7 +659,10 @@ class Cookidoo:
         portions: int | None = None,
         page: int | None = None,
         page_size: int | None = None,
-        tmv: ThermomixMachineType | str | list[ThermomixMachineType | str] | None = None,
+        tmv: ThermomixMachineType
+        | str
+        | list[ThermomixMachineType | str]
+        | None = None,
     ) -> CookidooSearchResult:
         """Search recipes in Cookidoo (GET).
 
@@ -718,22 +730,28 @@ class Cookidoo:
         params: dict[str, str] = {}
         if query is not None:
             params["query"] = query
-        if accessories is not None:
-            params["accessories"] = normalize_list_param(accessories)
-        if languages is not None:
-            params["languages"] = normalize_list_param(languages)
-        if categories is not None:
-            params["categories"] = normalize_list_param(categories)
-        if countries is not None:
-            params["countries"] = normalize_list_param(countries)
-        if ingredients is not None:
-            params["ingredients"] = normalize_list_param(ingredients)
-        if exclude_ingredients is not None:
-            params["excludeIngredients"] = normalize_list_param(exclude_ingredients)
-        if tags is not None:
-            params["tags"] = normalize_list_param(tags)
-        if ratings is not None:
-            params["ratings"] = normalize_list_param(ratings)
+        if accessories is not None and (
+            normalized := normalize_list_param(accessories)
+        ):
+            params["accessories"] = normalized
+        if languages is not None and (normalized := normalize_list_param(languages)):
+            params["languages"] = normalized
+        if categories is not None and (normalized := normalize_list_param(categories)):
+            params["categories"] = normalized
+        if countries is not None and (normalized := normalize_list_param(countries)):
+            params["countries"] = normalized
+        if ingredients is not None and (
+            normalized := normalize_list_param(ingredients)
+        ):
+            params["ingredients"] = normalized
+        if exclude_ingredients is not None and (
+            normalized := normalize_list_param(exclude_ingredients)
+        ):
+            params["excludeIngredients"] = normalized
+        if tags is not None and (normalized := normalize_list_param(tags)):
+            params["tags"] = normalized
+        if ratings is not None and (normalized := normalize_list_param(ratings)):
+            params["ratings"] = normalized
         if difficulty is not None:
             params["difficulty"] = difficulty
         if preparation_time is not None:
@@ -746,8 +764,8 @@ class Cookidoo:
             params["page"] = str(page)
         if page_size is not None:
             params["pageSize"] = str(page_size)
-        if tmv is not None:
-            params["tmv"] = normalize_tmv_param(tmv)
+        if tmv is not None and (normalized := normalize_tmv_param(tmv)):
+            params["tmv"] = normalized
         url = url.with_query(params)
         result = await self._request(
             "get", url, "search recipes", accepted_statuses=(HTTPStatus.OK,)
@@ -3407,4 +3425,3 @@ class Cookidoo:
             raise CookidooRequestException(
                 "Remove custom recipe from calendar failed due to request exception."
             ) from e
-

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -145,7 +145,7 @@ class Cookidoo:
         parsed = urlparse(self._cfg.localization.url)
         return URL(f"{parsed.scheme}://{parsed.netloc}")
 
-    async def _request(
+    async def _request_json(
         self,
         method: str,
         url: URL,
@@ -154,8 +154,8 @@ class Cookidoo:
         json: dict[str, Any] | list[Any] | None = None,
         headers: dict[str, str] | None = None,
         accepted_statuses: tuple[HTTPStatus, ...] = (HTTPStatus.OK,),
-    ) -> dict[str, Any] | None:
-        """Execute an HTTP request with standard error handling."""
+    ) -> Any | None:
+        """Execute an HTTP request and parse its JSON response."""
         merged_headers = {**self._api_headers, **(headers or {})}
 
         try:
@@ -188,7 +188,7 @@ class Cookidoo:
                 if r.status == HTTPStatus.NO_CONTENT:
                     return None
                 try:
-                    return cast(dict[str, Any], await r.json())
+                    return await r.json()
                 except (JSONDecodeError, KeyError) as e:
                     _LOGGER.debug(
                         "Exception: Cannot parse %s response:\n%s",
@@ -767,11 +767,15 @@ class Cookidoo:
         if tmv is not None and (normalized := normalize_tmv_param(tmv)):
             params["tmv"] = normalized
         url = url.with_query(params)
-        result = await self._request(
+        result = await self._request_json(
             "get", url, "search recipes", accepted_statuses=(HTTPStatus.OK,)
         )
         if result is None:
             return CookidooSearchResult(recipes=[], total=0)
+        if not isinstance(result, dict):
+            raise CookidooParseException(
+                "Search recipes failed during parsing of request response."
+            )
         return cookidoo_search_result_from_json(result, self._cfg.localization)
 
     async def get_custom_recipe(self, id: str) -> CookidooCustomRecipe:

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -180,6 +180,20 @@ class Cookidoo:
             HTTP status codes considered successful. Defaults to 200 and 204.
             A 204 response always returns ``None`` (no body).
 
+        Returns
+        -------
+        object | None
+            The parsed JSON response, or ``None`` for 204 No Content.
+
+        Raises
+        ------
+        CookidooAuthException
+            When the server responds with 401 Unauthorized.
+        CookidooRequestException
+            On connection timeout or other client errors.
+        CookidooParseException
+            When the response body cannot be parsed as JSON.
+
         """
         merged_headers = {**self._api_headers, **(headers or {})}
 

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -634,7 +634,7 @@ class Cookidoo:
 
     async def search_recipes(
         self,
-        query: str,
+        query: str | None = None,
         locale: str | None = None,
         accessories: str | list[str] | None = None,
         languages: str | list[str] | None = None,
@@ -660,7 +660,7 @@ class Cookidoo:
         Parameters
         ----------
         query
-            Search query (e.g. "chicken", "pasta").
+            Optional search query (e.g. "chicken", "pasta").
         locale
             Locale for the search path (e.g. "es", "en", "de").
             Defaults to the first part of the configured language (e.g. "de-CH" -> "de").
@@ -715,7 +715,9 @@ class Cookidoo:
         if locale is None:
             locale = self._cfg.localization.language.split("-")[0]
         url = self.api_endpoint / "search" / locale
-        params: dict[str, str] = {"query": query}
+        params: dict[str, str] = {}
+        if query is not None:
+            params["query"] = query
         if accessories is not None:
             params["accessories"] = normalize_list_param(accessories)
         if languages is not None:

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -58,6 +58,8 @@ from cookidoo_api.exceptions import (
     CookidooRequestException,
 )
 from cookidoo_api.helpers import (
+    normalize_list_param,
+    normalize_tmv_param,
     cookidoo_additional_item_from_json,
     cookidoo_calendar_day_from_json,
     cookidoo_collection_from_json,
@@ -96,29 +98,6 @@ from cookidoo_api.types import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _normalize_list_param(value: str | list[str] | None) -> str | None:
-    """Normalize list/string params to comma-separated string."""
-    if value is None:
-        return None
-    if isinstance(value, list):
-        return ",".join([v for v in value if v])
-    return value
-
-
-def _normalize_tmv_param(
-    value: ThermomixMachineType | str | list[ThermomixMachineType | str] | None,
-) -> str | None:
-    """Normalize TMV param to comma-separated string."""
-    if value is None:
-        return None
-    if isinstance(value, list):
-        normalized: list[str] = []
-        for item in value:
-            normalized.append(item.value if isinstance(item, ThermomixMachineType) else str(item))
-        return ",".join([v for v in normalized if v])
-    return value.value if isinstance(value, ThermomixMachineType) else value
 
 
 class Cookidoo:
@@ -738,21 +717,21 @@ class Cookidoo:
         url = self.api_endpoint / "search" / locale
         params: dict[str, str] = {"query": query}
         if accessories is not None:
-            params["accessories"] = _normalize_list_param(accessories)
+            params["accessories"] = normalize_list_param(accessories)
         if languages is not None:
-            params["languages"] = _normalize_list_param(languages)
+            params["languages"] = normalize_list_param(languages)
         if categories is not None:
-            params["categories"] = _normalize_list_param(categories)
+            params["categories"] = normalize_list_param(categories)
         if countries is not None:
-            params["countries"] = _normalize_list_param(countries)
+            params["countries"] = normalize_list_param(countries)
         if ingredients is not None:
-            params["ingredients"] = _normalize_list_param(ingredients)
+            params["ingredients"] = normalize_list_param(ingredients)
         if exclude_ingredients is not None:
-            params["excludeIngredients"] = _normalize_list_param(exclude_ingredients)
+            params["excludeIngredients"] = normalize_list_param(exclude_ingredients)
         if tags is not None:
-            params["tags"] = _normalize_list_param(tags)
+            params["tags"] = normalize_list_param(tags)
         if ratings is not None:
-            params["ratings"] = _normalize_list_param(ratings)
+            params["ratings"] = normalize_list_param(ratings)
         if difficulty is not None:
             params["difficulty"] = difficulty
         if preparation_time is not None:
@@ -766,7 +745,7 @@ class Cookidoo:
         if page_size is not None:
             params["pageSize"] = str(page_size)
         if tmv is not None:
-            params["tmv"] = _normalize_tmv_param(tmv)
+            params["tmv"] = normalize_tmv_param(tmv)
         url = url.with_query(params)
         result = await self._request(
             "get", url, "search recipes", accepted_statuses=(HTTPStatus.OK,)

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import re
 import time
 import traceback
-from typing import Any, cast
+from typing import cast
 from urllib.parse import urlparse
 
 from aiohttp import ClientError, ClientSession
@@ -80,6 +80,7 @@ from cookidoo_api.raw_types import (
     ManagedCollectionJSON,
     RecipeDetailsJSON,
     RecipeJSON,
+    SearchResultJSON,
 )
 from cookidoo_api.types import (
     CookidooAdditionalItem,
@@ -151,16 +152,40 @@ class Cookidoo:
         url: URL,
         operation: str,
         *,
-        json: dict[str, Any] | list[Any] | None = None,
+        params: dict[str, str] | None = None,
+        json: object | None = None,
         headers: dict[str, str] | None = None,
-        accepted_statuses: tuple[HTTPStatus, ...] = (HTTPStatus.OK,),
-    ) -> Any | None:
-        """Execute an HTTP request and parse its JSON response."""
+        accepted_statuses: tuple[HTTPStatus, ...] = (
+            HTTPStatus.OK,
+            HTTPStatus.NO_CONTENT,
+        ),
+    ) -> object | None:
+        """Execute an HTTP request and parse its JSON response.
+
+        Parameters
+        ----------
+        method
+            HTTP method (e.g. "get", "post").
+        url
+            The target URL (without query params when using ``params``).
+        operation
+            Human-readable operation name for error messages.
+        params
+            Optional query parameters passed to aiohttp.
+        json
+            Optional JSON body for the request.
+        headers
+            Optional extra headers (merged with default API headers).
+        accepted_statuses
+            HTTP status codes considered successful. Defaults to 200 and 204.
+            A 204 response always returns ``None`` (no body).
+
+        """
         merged_headers = {**self._api_headers, **(headers or {})}
 
         try:
             async with self._session.request(
-                method, url, headers=merged_headers, json=json
+                method, url, headers=merged_headers, json=json, params=params
             ) as r:
                 _LOGGER.debug(
                     "Response from %s [%s]: %s", url, r.status, await r.text()
@@ -188,7 +213,7 @@ class Cookidoo:
                 if r.status == HTTPStatus.NO_CONTENT:
                     return None
                 try:
-                    return await r.json()
+                    result: object = await r.json()
                 except (JSONDecodeError, KeyError) as e:
                     _LOGGER.debug(
                         "Exception: Cannot parse %s response:\n%s",
@@ -198,6 +223,8 @@ class Cookidoo:
                     raise CookidooParseException(
                         f"{operation.capitalize()} failed during parsing of request response."
                     ) from e
+                else:
+                    return result
 
         except (
             CookidooAuthException,
@@ -766,17 +793,16 @@ class Cookidoo:
             params["pageSize"] = str(page_size)
         if tmv is not None and (normalized := normalize_tmv_param(tmv)):
             params["tmv"] = normalized
-        url = url.with_query(params)
-        result = await self._request_json(
-            "get", url, "search recipes", accepted_statuses=(HTTPStatus.OK,)
-        )
+        result = await self._request_json("get", url, "search recipes", params=params)
         if result is None:
             return CookidooSearchResult(recipes=[], total=0)
         if not isinstance(result, dict):
             raise CookidooParseException(
                 "Search recipes failed during parsing of request response."
             )
-        return cookidoo_search_result_from_json(result, self._cfg.localization)
+        return cookidoo_search_result_from_json(
+            cast(SearchResultJSON, result), self._cfg.localization
+        )
 
     async def get_custom_recipe(self, id: str) -> CookidooCustomRecipe:
         """Get custom recipe.

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -41,6 +41,8 @@ from cookidoo_api.types import (
     CookidooNutritionGroup,
     CookidooRecipeCollection,
     CookidooRecipeNutrition,
+    CookidooSearchRecipeHit,
+    CookidooSearchResult,
     CookidooShoppingRecipe,
     CookidooShoppingRecipeDetails,
     CookidooSubscription,
@@ -203,6 +205,44 @@ def cookidoo_recipe_from_json(
         image=image,
         url=url,
     )
+
+
+def cookidoo_search_result_from_json(
+    data: dict,
+    localization: CookidooLocalizationConfig | None = None,
+) -> CookidooSearchResult:
+    """Convert a search result received from the API to a CookidooSearchResult.
+
+    The API may return recipes in ``data`` (search endpoint) or ``recipes``;
+    total is optional and defaults to len(recipes).
+    """
+    recipes_data = data.get("data") or data.get("recipes") or []
+    total = data.get("total")
+    if total is None or not isinstance(total, int):
+        total = len(recipes_data) if isinstance(recipes_data, list) else 0
+    hits: list[CookidooSearchRecipeHit] = []
+    for item in recipes_data:
+        if not isinstance(item, dict):
+            continue
+        recipe_id = item.get("id", "")
+        name = item.get("title") or item.get("name", "")
+        thumbnail, image = None, None
+        descriptive_assets = item.get("descriptiveAssets")
+        if descriptive_assets and isinstance(descriptive_assets, list):
+            thumbnail, image = _extract_images_from_descriptive_assets(
+                cast(list[DescriptiveAssetJSON], descriptive_assets)
+            )
+        url = _construct_recipe_url(localization, recipe_id)
+        hits.append(
+            CookidooSearchRecipeHit(
+                id=recipe_id,
+                name=name,
+                thumbnail=thumbnail,
+                image=image,
+                url=url,
+            )
+        )
+    return CookidooSearchResult(recipes=hits, total=total)
 
 
 def cookidoo_quantity_from_json(

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from typing import cast
+from typing import Any, cast
 from urllib.parse import urlparse
 
 import aiofiles
@@ -234,7 +234,7 @@ def cookidoo_recipe_from_json(
 
 
 def cookidoo_search_result_from_json(
-    data: dict,
+    data: dict[str, Any],
     localization: CookidooLocalizationConfig | None = None,
 ) -> CookidooSearchResult:
     """Convert a search result received from the API to a CookidooSearchResult.

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -47,11 +47,37 @@ from cookidoo_api.types import (
     CookidooShoppingRecipeDetails,
     CookidooSubscription,
     CookidooUserInfo,
+    ThermomixMachineType,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 localization_file_path = os.path.join(os.path.dirname(__file__), "localization.json")
+
+
+def normalize_list_param(value: str | list[str] | None) -> str | None:
+    """Normalize list/string params to comma-separated string."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return ",".join([v for v in value if v])
+    return value
+
+
+def normalize_tmv_param(
+    value: ThermomixMachineType | str | list[ThermomixMachineType | str] | None,
+) -> str | None:
+    """Normalize TMV param to comma-separated string."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        normalized: list[str] = []
+        for item in value:
+            normalized.append(
+                item.value if isinstance(item, ThermomixMachineType) else str(item)
+            )
+        return ",".join([v for v in normalized if v])
+    return value.value if isinstance(value, ThermomixMachineType) else value
 
 
 def cookidoo_user_info_from_json(

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from typing import Any, cast
+from typing import cast
 from urllib.parse import urlparse
 
 import aiofiles
@@ -23,6 +23,8 @@ from cookidoo_api.raw_types import (
     QuantityJSON,
     RecipeDetailsJSON,
     RecipeJSON,
+    SearchRecipeHitJSON,
+    SearchResultJSON,
     SubscriptionJSON,
 )
 from cookidoo_api.types import (
@@ -234,7 +236,7 @@ def cookidoo_recipe_from_json(
 
 
 def cookidoo_search_result_from_json(
-    data: dict[str, Any],
+    data: SearchResultJSON,
     localization: CookidooLocalizationConfig | None = None,
 ) -> CookidooSearchResult:
     """Convert a search result received from the API to a CookidooSearchResult.
@@ -242,10 +244,11 @@ def cookidoo_search_result_from_json(
     The API may return recipes in ``data`` (search endpoint) or ``recipes``;
     total is optional and defaults to len(recipes).
     """
-    recipes_data = data.get("data") or data.get("recipes") or []
-    total = data.get("total")
-    if total is None or not isinstance(total, int):
-        total = len(recipes_data) if isinstance(recipes_data, list) else 0
+    raw_recipes: list[SearchRecipeHitJSON] = (
+        data.get("data") or data.get("recipes") or []
+    )
+    recipes_data: list[object] = list(raw_recipes)
+    total_raw = data.get("total")
     hits: list[CookidooSearchRecipeHit] = []
     for item in recipes_data:
         if not isinstance(item, dict):
@@ -256,7 +259,7 @@ def cookidoo_search_result_from_json(
         descriptive_assets = item.get("descriptiveAssets")
         if descriptive_assets and isinstance(descriptive_assets, list):
             thumbnail, image = _extract_images_from_descriptive_assets(
-                cast(list[DescriptiveAssetJSON], descriptive_assets)
+                descriptive_assets
             )
         url = _construct_recipe_url(localization, recipe_id)
         hits.append(
@@ -268,6 +271,7 @@ def cookidoo_search_result_from_json(
                 url=url,
             )
         )
+    total = total_raw if isinstance(total_raw, int) else len(hits)
     return CookidooSearchResult(recipes=hits, total=total)
 
 

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -242,7 +242,20 @@ def cookidoo_search_result_from_json(
     """Convert a search result received from the API to a CookidooSearchResult.
 
     The API may return recipes in ``data`` (search endpoint) or ``recipes``;
-    total is optional and defaults to len(recipes).
+    total is optional and defaults to the number of valid parsed hits.
+
+    Parameters
+    ----------
+    data
+        The raw JSON response from the search API.
+    localization
+        Optional localization config used to construct recipe URLs.
+
+    Returns
+    -------
+    CookidooSearchResult
+        The parsed search result with recipe hits and total count.
+
     """
     raw_recipes: list[SearchRecipeHitJSON] = (
         data.get("data") or data.get("recipes") or []

--- a/cookidoo_api/raw_types.py
+++ b/cookidoo_api/raw_types.py
@@ -289,4 +289,21 @@ class CalendarDayJSON(TypedDict):
     customerRecipeIds: NotRequired[list[str]]
 
 
+class SearchRecipeHitJSON(TypedDict, total=False):
+    """The json for a single recipe hit in search results."""
+
+    id: str
+    title: str
+    name: str
+    descriptiveAssets: list[DescriptiveAssetJSON] | None
+
+
+class SearchResultJSON(TypedDict, total=False):
+    """The json for a search result from the API."""
+
+    data: list[SearchRecipeHitJSON]
+    recipes: list[SearchRecipeHitJSON]
+    total: int
+
+
 __all__ = ["QuantityJSON"]

--- a/cookidoo_api/types.py
+++ b/cookidoo_api/types.py
@@ -1,6 +1,16 @@
 """Cookidoo API types."""
 
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ThermomixMachineType(str, Enum):
+    """Thermomix machine types."""
+
+    TM5 = "TM5"
+    TM6 = "TM6"
+    TM7 = "TM7"
+    TM31 = "TM31"
 
 
 @dataclass
@@ -144,6 +154,49 @@ class CookidooShoppingRecipe:
     thumbnail: str | None
     image: str | None
     url: str
+
+
+@dataclass
+class CookidooSearchRecipeHit:
+    """A single recipe hit from Cookidoo search.
+
+    Attributes
+    ----------
+    id
+        The id of the recipe
+    name
+        The title of the recipe
+    thumbnail
+        The thumbnail image URL (small preview)
+    image
+        The full-size image URL
+    url
+        The URL of the recipe
+
+    """
+
+    id: str
+    name: str
+    thumbnail: str | None
+    image: str | None
+    url: str
+
+
+@dataclass
+class CookidooSearchResult:
+    """Cookidoo search result type.
+
+    Attributes
+    ----------
+    recipes
+        List of recipe hits matching the search
+    total
+        Total number of matching recipes
+
+    """
+
+    recipes: list[CookidooSearchRecipeHit]
+    total: int
 
 
 @dataclass

--- a/cookidoo_api/types.py
+++ b/cookidoo_api/types.py
@@ -1,10 +1,10 @@
 """Cookidoo API types."""
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 
-class ThermomixMachineType(str, Enum):
+class ThermomixMachineType(StrEnum):
     """Thermomix machine types."""
 
     TM5 = "TM5"

--- a/smoke_test/test_2_methods.py
+++ b/smoke_test/test_2_methods.py
@@ -48,6 +48,17 @@ class TestMethods:
         assert recipe_details.id == recipe_id
         assert recipe_details.name == name
 
+    async def test_cookidoo_search_recipes(self, cookidoo: Cookidoo) -> None:
+        """Test cookidoo search recipes."""
+        result = await cookidoo.search_recipes("Brötchen")
+        assert hasattr(result, "recipes") and hasattr(result, "total")
+        assert isinstance(result.recipes, list)
+        assert isinstance(result.total, int)
+        assert result.total >= len(result.recipes)
+        if result.recipes:
+            recipe = result.recipes[0]
+            assert hasattr(recipe, "id") and hasattr(recipe, "name")
+
     async def test_cookidoo_shopping_list_recipe_and_ingredients(
         self, cookidoo: Cookidoo
     ) -> None:

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -86,6 +86,11 @@ COOKIDOO_TEST_RESPONSE_INACTIVE_SUBSCRIPTION: Final = [
     }
 ]
 
+COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES: Final = {
+    "recipes": [],
+    "total": 0,
+}
+
 COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS = {
     "id": "r907015",
     "tags": [

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -87,8 +87,37 @@ COOKIDOO_TEST_RESPONSE_INACTIVE_SUBSCRIPTION: Final = [
 ]
 
 COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES: Final = {
-    "recipes": [],
-    "total": 0,
+    "recipes": [
+        {
+            "id": "r123456",
+            "title": "Chicken Soup",
+            "descriptiveAssets": [
+                {
+                    "square": (
+                        "https://assets.tmecosys.com/image/upload/"
+                        "{transformation}/img/recipe/ras/Assets/"
+                        "a1b2c3d4-1111-2222-3333-444455556666/Derivates/"
+                        "abcdef01-2345-6789-abcd-ef0123456789.jpg"
+                    ),
+                }
+            ],
+        },
+        {
+            "id": "r654321",
+            "name": "Chicken Salad",
+            "descriptiveAssets": [
+                {
+                    "landscape": (
+                        "https://assets.tmecosys.com/image/upload/"
+                        "{transformation}/img/recipe/ras/Assets/"
+                        "f1e2d3c4-9999-8888-7777-666655554444/Derivates/"
+                        "98765432-10fe-dcba-9876-543210fedcba.jpg"
+                    ),
+                }
+            ],
+        },
+    ],
+    "total": 2,
 }
 
 COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS = {

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -21,6 +21,7 @@ from cookidoo_api.types import (
     CookidooConfig,
     CookidooIngredientItem,
     CookidooSearchResult,
+    ThermomixMachineType,
 )
 from tests.responses import (
     COOKIDOO_TEST_LOGIN_PAGE_HTML,
@@ -685,6 +686,86 @@ class TestSearchRecipes:
         )
         with pytest.raises(CookidooAuthException):
             await cookidoo.search_recipes("chicken")
+
+    async def test_search_recipes_unauthorized_non_json_body(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes 401 with non-JSON body still raises CookidooAuthException."""
+        mocked.get(
+            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            status=HTTPStatus.UNAUTHORIZED,
+            body="not json",
+            content_type="text/plain",
+        )
+        with pytest.raises(CookidooAuthException):
+            await cookidoo.search_recipes("chicken")
+
+    async def test_search_recipes_parse_exception(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes raises CookidooParseException when response is not valid JSON."""
+        mocked.get(
+            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            status=HTTPStatus.OK,
+            body="not valid json",
+            content_type="application/json",
+        )
+        with pytest.raises(CookidooParseException):
+            await cookidoo.search_recipes("chicken")
+
+    async def test_search_recipes_no_content(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes when API returns 204 No Content."""
+        mocked.get(
+            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            status=HTTPStatus.NO_CONTENT,
+        )
+
+        data = await cookidoo.search_recipes("chicken")
+        assert isinstance(data, CookidooSearchResult)
+        assert data.recipes == []
+        assert data.total == 0
+
+    async def test_search_recipes_with_string_params(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes with string (non-list) filter params."""
+        url = (
+            "https://ch.tmmobile.vorwerk-digital.com/search/de?"
+            "query=pasta&accessories=includingFriend&difficulty=easy"
+        )
+        mocked.get(
+            url,
+            payload=COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
+            status=HTTPStatus.OK,
+        )
+
+        data = await cookidoo.search_recipes(
+            "pasta",
+            accessories="includingFriend",
+            difficulty="easy",
+        )
+        assert isinstance(data, CookidooSearchResult)
+        assert data.total == 0
+
+    async def test_search_recipes_with_tmv_single_enum(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes with single ThermomixMachineType (not list)."""
+        url = (
+            "https://ch.tmmobile.vorwerk-digital.com/search/de?"
+            "query=soup&tmv=TM7"
+        )
+        mocked.get(
+            url,
+            payload=COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
+            status=HTTPStatus.OK,
+        )
+
+        data = await cookidoo.search_recipes("soup", tmv=ThermomixMachineType.TM7)
+        assert isinstance(data, CookidooSearchResult)
+        assert data.total == 0
 
 
 class TestGetCustomRecipe:

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -779,6 +779,29 @@ class TestSearchRecipes:
         assert data.recipes == []
         assert data.total == 0
 
+    async def test_search_recipes_unexpected_status(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes raises CookidooRequestException on unexpected status."""
+        mocked.get(
+            "https://cookidoo.ch/search/de?query=chicken",
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
+        with pytest.raises(CookidooRequestException):
+            await cookidoo.search_recipes("chicken")
+
+    async def test_search_recipes_non_dict_response(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes raises CookidooParseException when response is not a dict."""
+        mocked.get(
+            "https://cookidoo.ch/search/de?query=chicken",
+            payload=["not", "a", "dict"],
+            status=HTTPStatus.OK,
+        )
+        with pytest.raises(CookidooParseException):
+            await cookidoo.search_recipes("chicken")
+
 
 class TestGetCustomRecipe:
     """Tests for get_custom_recipe method."""

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -589,8 +589,42 @@ class TestSearchRecipes:
 
         data = await cookidoo.search_recipes("chicken")
         assert isinstance(data, CookidooSearchResult)
-        assert data.recipes == []
-        assert data.total == 0
+        assert data.total == 2
+        assert len(data.recipes) == 2
+        assert data.recipes[0].id == "r123456"
+        assert data.recipes[0].name == "Chicken Soup"
+        assert data.recipes[0].thumbnail == (
+            "https://assets.tmecosys.com/image/upload/"
+            "t_web_shared_recipe_221x240/img/recipe/ras/Assets/"
+            "a1b2c3d4-1111-2222-3333-444455556666/Derivates/"
+            "abcdef01-2345-6789-abcd-ef0123456789.jpg"
+        )
+        assert data.recipes[0].image == (
+            "https://assets.tmecosys.com/image/upload/"
+            "t_web_rdp_recipe_584x480_1_5x/img/recipe/ras/Assets/"
+            "a1b2c3d4-1111-2222-3333-444455556666/Derivates/"
+            "abcdef01-2345-6789-abcd-ef0123456789.jpg"
+        )
+        assert data.recipes[0].url == (
+            "https://cookidoo.ch/recipes/recipe/de-CH/r123456"
+        )
+        assert data.recipes[1].id == "r654321"
+        assert data.recipes[1].name == "Chicken Salad"
+        assert data.recipes[1].thumbnail == (
+            "https://assets.tmecosys.com/image/upload/"
+            "t_web_shared_recipe_221x240/img/recipe/ras/Assets/"
+            "f1e2d3c4-9999-8888-7777-666655554444/Derivates/"
+            "98765432-10fe-dcba-9876-543210fedcba.jpg"
+        )
+        assert data.recipes[1].image == (
+            "https://assets.tmecosys.com/image/upload/"
+            "t_web_rdp_recipe_584x480_1_5x/img/recipe/ras/Assets/"
+            "f1e2d3c4-9999-8888-7777-666655554444/Derivates/"
+            "98765432-10fe-dcba-9876-543210fedcba.jpg"
+        )
+        assert data.recipes[1].url == (
+            "https://cookidoo.ch/recipes/recipe/de-CH/r654321"
+        )
 
     async def test_search_recipes_with_options(
         self, mocked: aioresponses, cookidoo: Cookidoo
@@ -653,8 +687,8 @@ class TestSearchRecipes:
             tmv=["TM7", "TM6", "TM5", "TM31"],
         )
         assert isinstance(data, CookidooSearchResult)
-        assert data.recipes == []
-        assert data.total == 0
+        assert len(data.recipes) == 2
+        assert data.total == 2
 
     @pytest.mark.parametrize(
         "exception",
@@ -747,7 +781,7 @@ class TestSearchRecipes:
             difficulty="easy",
         )
         assert isinstance(data, CookidooSearchResult)
-        assert data.total == 0
+        assert data.total == 2
 
     async def test_search_recipes_with_tmv_single_enum(
         self, mocked: aioresponses, cookidoo: Cookidoo
@@ -762,7 +796,7 @@ class TestSearchRecipes:
 
         data = await cookidoo.search_recipes("soup", tmv=ThermomixMachineType.TM7)
         assert isinstance(data, CookidooSearchResult)
-        assert data.total == 0
+        assert data.total == 2
 
     async def test_search_recipes_without_query(
         self, mocked: aioresponses, cookidoo: Cookidoo
@@ -776,8 +810,8 @@ class TestSearchRecipes:
 
         data = await cookidoo.search_recipes()
         assert isinstance(data, CookidooSearchResult)
-        assert data.recipes == []
-        assert data.total == 0
+        assert len(data.recipes) == 2
+        assert data.total == 2
 
     async def test_search_recipes_unexpected_status(
         self, mocked: aioresponses, cookidoo: Cookidoo

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -47,11 +47,11 @@ from tests.responses import (
     COOKIDOO_TEST_RESPONSE_GET_MANAGED_COLLECTIONS,
     COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS,
     COOKIDOO_TEST_RESPONSE_GET_SHOPPING_LIST_RECIPES,
-    COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
     COOKIDOO_TEST_RESPONSE_INACTIVE_SUBSCRIPTION,
     COOKIDOO_TEST_RESPONSE_REMOVE_CUSTOM_RECIPE_FROM_CALENDAR,
     COOKIDOO_TEST_RESPONSE_REMOVE_RECIPE_FROM_CALENDAR,
     COOKIDOO_TEST_RESPONSE_REMOVE_RECIPE_FROM_CUSTOM_COLLECTION,
+    COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
     COOKIDOO_TEST_RESPONSE_USER_INFO,
 )
 
@@ -582,7 +582,7 @@ class TestSearchRecipes:
     ) -> None:
         """Test for search_recipes."""
         mocked.get(
-            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            "https://cookidoo.ch/search/de?query=chicken",
             payload=COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
             status=HTTPStatus.OK,
         )
@@ -609,7 +609,7 @@ class TestSearchRecipes:
             "VrkNavCategory-RPF-003",
         ]
         url = (
-            "https://ch.tmmobile.vorwerk-digital.com/search/es?"
+            "https://cookidoo.ch/search/es?"
             "query=chicken"
             "&accessories=includingFriend,includingBladeCover,includingBladeCoverWithPeeler,includingCutter,includingSensor"
             "&languages=en,es"
@@ -668,7 +668,7 @@ class TestSearchRecipes:
     ) -> None:
         """Test search_recipes request exceptions."""
         mocked.get(
-            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            "https://cookidoo.ch/search/de?query=chicken",
             exception=exception,
         )
 
@@ -680,7 +680,7 @@ class TestSearchRecipes:
     ) -> None:
         """Test search_recipes unauthorized exception."""
         mocked.get(
-            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            "https://cookidoo.ch/search/de?query=chicken",
             status=HTTPStatus.UNAUTHORIZED,
             payload={"error_description": ""},
         )
@@ -692,7 +692,7 @@ class TestSearchRecipes:
     ) -> None:
         """Test search_recipes 401 with non-JSON body still raises CookidooAuthException."""
         mocked.get(
-            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            "https://cookidoo.ch/search/de?query=chicken",
             status=HTTPStatus.UNAUTHORIZED,
             body="not json",
             content_type="text/plain",
@@ -705,7 +705,7 @@ class TestSearchRecipes:
     ) -> None:
         """Test search_recipes raises CookidooParseException when response is not valid JSON."""
         mocked.get(
-            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            "https://cookidoo.ch/search/de?query=chicken",
             status=HTTPStatus.OK,
             body="not valid json",
             content_type="application/json",
@@ -718,7 +718,7 @@ class TestSearchRecipes:
     ) -> None:
         """Test search_recipes when API returns 204 No Content."""
         mocked.get(
-            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            "https://cookidoo.ch/search/de?query=chicken",
             status=HTTPStatus.NO_CONTENT,
         )
 
@@ -732,7 +732,7 @@ class TestSearchRecipes:
     ) -> None:
         """Test search_recipes with string (non-list) filter params."""
         url = (
-            "https://ch.tmmobile.vorwerk-digital.com/search/de?"
+            "https://cookidoo.ch/search/de?"
             "query=pasta&accessories=includingFriend&difficulty=easy"
         )
         mocked.get(
@@ -753,10 +753,7 @@ class TestSearchRecipes:
         self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:
         """Test search_recipes with single ThermomixMachineType (not list)."""
-        url = (
-            "https://ch.tmmobile.vorwerk-digital.com/search/de?"
-            "query=soup&tmv=TM7"
-        )
+        url = "https://cookidoo.ch/search/de?query=soup&tmv=TM7"
         mocked.get(
             url,
             payload=COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
@@ -772,7 +769,7 @@ class TestSearchRecipes:
     ) -> None:
         """Test search_recipes with optional query omitted (params without query)."""
         mocked.get(
-            "https://ch.tmmobile.vorwerk-digital.com/search/de",
+            "https://cookidoo.ch/search/de",
             payload=COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
             status=HTTPStatus.OK,
         )

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -20,6 +20,7 @@ from cookidoo_api.types import (
     CookidooAdditionalItem,
     CookidooConfig,
     CookidooIngredientItem,
+    CookidooSearchResult,
 )
 from tests.responses import (
     COOKIDOO_TEST_LOGIN_PAGE_HTML,
@@ -45,6 +46,7 @@ from tests.responses import (
     COOKIDOO_TEST_RESPONSE_GET_MANAGED_COLLECTIONS,
     COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS,
     COOKIDOO_TEST_RESPONSE_GET_SHOPPING_LIST_RECIPES,
+    COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
     COOKIDOO_TEST_RESPONSE_INACTIVE_SUBSCRIPTION,
     COOKIDOO_TEST_RESPONSE_REMOVE_CUSTOM_RECIPE_FROM_CALENDAR,
     COOKIDOO_TEST_RESPONSE_REMOVE_RECIPE_FROM_CALENDAR,
@@ -569,6 +571,120 @@ class TestGetRecipeDetails:
 
         with pytest.raises(exception):
             await cookidoo.get_recipe_details("r907015")
+
+
+class TestSearchRecipes:
+    """Tests for search_recipes method."""
+
+    async def test_search_recipes(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test for search_recipes."""
+        mocked.get(
+            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            payload=COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
+            status=HTTPStatus.OK,
+        )
+
+        data = await cookidoo.search_recipes("chicken")
+        assert isinstance(data, CookidooSearchResult)
+        assert data.recipes == []
+        assert data.total == 0
+
+    async def test_search_recipes_with_options(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes with filters and list parameters."""
+        accessories = [
+            "includingFriend",
+            "includingBladeCover",
+            "includingBladeCoverWithPeeler",
+            "includingCutter",
+            "includingSensor",
+        ]
+        categories = [
+            "VrkNavCategory-RPF-001",
+            "VrkNavCategory-RPF-002",
+            "VrkNavCategory-RPF-003",
+        ]
+        url = (
+            "https://ch.tmmobile.vorwerk-digital.com/search/es?"
+            "query=chicken"
+            "&accessories=includingFriend,includingBladeCover,includingBladeCoverWithPeeler,includingCutter,includingSensor"
+            "&languages=en,es"
+            "&categories=VrkNavCategory-RPF-001,VrkNavCategory-RPF-002,VrkNavCategory-RPF-003"
+            "&countries=ar,es"
+            "&ingredients=sal,aceite%20de%20oliva"
+            "&excludeIngredients=polvo%20de%20hornear"
+            "&tags=De%20diario"
+            "&ratings=5,4"
+            "&difficulty=easy"
+            "&preparationTime=900"
+            "&totalTime=1200"
+            "&portions=2"
+            "&page=1"
+            "&pageSize=10"
+            "&tmv=TM7,TM6,TM5,TM31"
+        )
+        mocked.get(
+            url,
+            payload=COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
+            status=HTTPStatus.OK,
+        )
+
+        data = await cookidoo.search_recipes(
+            "chicken",
+            locale="es",
+            accessories=accessories,
+            languages=["en", "es"],
+            categories=categories,
+            countries=["ar", "es"],
+            ingredients=["sal", "aceite de oliva"],
+            exclude_ingredients=["polvo de hornear"],
+            tags=["De diario"],
+            ratings=["5", "4"],
+            difficulty="easy",
+            preparation_time=900,
+            total_time=1200,
+            portions=2,
+            page=1,
+            page_size=10,
+            tmv=["TM7", "TM6", "TM5", "TM31"],
+        )
+        assert isinstance(data, CookidooSearchResult)
+        assert data.recipes == []
+        assert data.total == 0
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            TimeoutError,
+            ClientError,
+        ],
+    )
+    async def test_search_recipes_request_exception(
+        self, mocked: aioresponses, cookidoo: Cookidoo, exception: Exception
+    ) -> None:
+        """Test search_recipes request exceptions."""
+        mocked.get(
+            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            exception=exception,
+        )
+
+        with pytest.raises(CookidooRequestException):
+            await cookidoo.search_recipes("chicken")
+
+    async def test_search_recipes_unauthorized(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes unauthorized exception."""
+        mocked.get(
+            "https://ch.tmmobile.vorwerk-digital.com/search/de?query=chicken",
+            status=HTTPStatus.UNAUTHORIZED,
+            payload={"error_description": ""},
+        )
+        with pytest.raises(CookidooAuthException):
+            await cookidoo.search_recipes("chicken")
 
 
 class TestGetCustomRecipe:

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -767,6 +767,21 @@ class TestSearchRecipes:
         assert isinstance(data, CookidooSearchResult)
         assert data.total == 0
 
+    async def test_search_recipes_without_query(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test search_recipes with optional query omitted (params without query)."""
+        mocked.get(
+            "https://ch.tmmobile.vorwerk-digital.com/search/de",
+            payload=COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
+            status=HTTPStatus.OK,
+        )
+
+        data = await cookidoo.search_recipes()
+        assert isinstance(data, CookidooSearchResult)
+        assert data.recipes == []
+        assert data.total == 0
+
 
 class TestGetCustomRecipe:
     """Tests for get_custom_recipe method."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,13 +1,11 @@
 """Unit tests for cookidoo-api."""
 
-from typing import cast
+from typing import Any, cast
 
 from dotenv import load_dotenv
 import pytest
 
 from cookidoo_api.helpers import (
-    normalize_list_param,
-    normalize_tmv_param,
     cookidoo_calendar_day_from_json,
     cookidoo_custom_recipe_from_json,
     cookidoo_recipe_details_from_json,
@@ -16,6 +14,8 @@ from cookidoo_api.helpers import (
     get_country_options,
     get_language_options,
     get_localization_options,
+    normalize_list_param,
+    normalize_tmv_param,
 )
 from cookidoo_api.raw_types import (
     CalendarDayJSON,
@@ -367,7 +367,7 @@ class TestCookidooSearchResultFromJson:
 
     def test_search_result_total_invalid_defaults_to_length(self) -> None:
         """When total is missing or not int, it defaults to len(recipes)."""
-        data = {"recipes": [{"id": "r1", "title": "X"}]}
+        data: dict[str, Any] = {"recipes": [{"id": "r1", "title": "X"}]}
         result = cookidoo_search_result_from_json(data, None)
         assert result.total == 1
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,10 +6,13 @@ from dotenv import load_dotenv
 import pytest
 
 from cookidoo_api.helpers import (
+    normalize_list_param,
+    normalize_tmv_param,
     cookidoo_calendar_day_from_json,
     cookidoo_custom_recipe_from_json,
     cookidoo_recipe_details_from_json,
     cookidoo_recipe_from_json,
+    cookidoo_search_result_from_json,
     get_country_options,
     get_language_options,
     get_localization_options,
@@ -21,7 +24,7 @@ from cookidoo_api.raw_types import (
     RecipeDetailsJSON,
     RecipeJSON,
 )
-from cookidoo_api.types import CookidooLocalizationConfig
+from cookidoo_api.types import CookidooLocalizationConfig, ThermomixMachineType
 from tests.responses import (
     COOKIDOO_TEST_RESPONSE_CALENDAR_WEEK,
     COOKIDOO_TEST_RESPONSE_GET_CUSTOM_RECIPE,
@@ -56,6 +59,40 @@ class TestLocalization:
 
         with pytest.raises(StopIteration):
             cookidoo_recipe_details_from_json(JSON)
+
+
+class TestSearchRecipeNormalizeHelpers:
+    """Tests for normalize_list_param and normalize_tmv_param."""
+
+    def test_normalize_list_param_none(self) -> None:
+        """normalize_list_param returns None when value is None."""
+        assert normalize_list_param(None) is None
+
+    def test_normalize_list_param_string_unchanged(self) -> None:
+        """normalize_list_param returns string unchanged."""
+        assert normalize_list_param("a,b") == "a,b"
+
+    def test_normalize_list_param_joins_list(self) -> None:
+        """normalize_list_param joins list to comma-separated string."""
+        assert normalize_list_param(["a", "b"]) == "a,b"
+        assert normalize_list_param(["x"]) == "x"
+        assert normalize_list_param(["a", "", "b"]) == "a,b"
+
+    def test_normalize_tmv_param_none(self) -> None:
+        """normalize_tmv_param returns None when value is None."""
+        assert normalize_tmv_param(None) is None
+
+    def test_normalize_tmv_param_single_enum(self) -> None:
+        """normalize_tmv_param returns enum value for single ThermomixMachineType."""
+        assert normalize_tmv_param(ThermomixMachineType.TM7) == "TM7"
+
+    def test_normalize_tmv_param_single_str(self) -> None:
+        """normalize_tmv_param returns str unchanged for single string."""
+        assert normalize_tmv_param("TM6") == "TM6"
+
+    def test_normalize_tmv_param_list(self) -> None:
+        """normalize_tmv_param joins list of enum/str to comma-separated."""
+        assert normalize_tmv_param([ThermomixMachineType.TM5, "TM6"]) == "TM5,TM6"
 
 
 class TestRecipeImagesAndUrls:
@@ -289,3 +326,78 @@ class TestRecipeImagesAndUrls:
         assert len(result.recipes) == 2
         assert result.recipes[0].id == "r214846"
         assert result.recipes[1].id == "r214846"
+
+
+class TestCookidooSearchResultFromJson:
+    """Tests for cookidoo_search_result_from_json."""
+
+    def test_search_result_uses_data_key(self) -> None:
+        """Search result reads from 'data' key when 'recipes' is missing."""
+        data = {
+            "data": [
+                {"id": "r1", "title": "Recipe One"},
+                {"id": "r2", "name": "Recipe Two"},
+            ],
+            "total": 2,
+        }
+        result = cookidoo_search_result_from_json(data, None)
+        assert len(result.recipes) == 2
+        assert result.recipes[0].id == "r1"
+        assert result.recipes[0].name == "Recipe One"
+        assert result.recipes[1].id == "r2"
+        assert result.recipes[1].name == "Recipe Two"
+        assert result.total == 2
+
+    def test_search_result_skips_non_dict_items(self) -> None:
+        """Non-dict items in recipes list are skipped; only dicts become hits."""
+        data = {
+            "recipes": [
+                {"id": "r1", "title": "A"},
+                "not-a-dict",
+                None,
+                {"id": "r2", "name": "B"},
+            ],
+        }
+        result = cookidoo_search_result_from_json(data, None)
+        assert len(result.recipes) == 2
+        assert result.recipes[0].id == "r1"
+        assert result.recipes[1].id == "r2"
+        # When total is missing, helper uses len(recipes_data)
+        assert result.total == 4
+
+    def test_search_result_total_invalid_defaults_to_length(self) -> None:
+        """When total is missing or not int, it defaults to len(recipes)."""
+        data = {"recipes": [{"id": "r1", "title": "X"}]}
+        result = cookidoo_search_result_from_json(data, None)
+        assert result.total == 1
+
+        data["total"] = "nope"
+        result = cookidoo_search_result_from_json(data, None)
+        assert result.total == 1
+
+    def test_search_result_with_descriptive_assets(self) -> None:
+        """Search result extracts thumbnail and image from descriptiveAssets."""
+        localization = CookidooLocalizationConfig(
+            country_code="ch", language="de-CH", url="https://cookidoo.ch"
+        )
+        data = {
+            "recipes": [
+                {
+                    "id": "r123",
+                    "title": "Test",
+                    "descriptiveAssets": [
+                        {
+                            "square": "https://example.com/square.png",
+                            "portrait": "https://example.com/portrait.png",
+                            "landscape": "https://example.com/landscape.png",
+                        }
+                    ],
+                }
+            ],
+            "total": 1,
+        }
+        result = cookidoo_search_result_from_json(data, localization)
+        assert len(result.recipes) == 1
+        assert result.recipes[0].thumbnail is not None
+        assert result.recipes[0].image is not None
+        assert result.recipes[0].url == "https://cookidoo.ch/recipes/recipe/de-CH/r123"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 """Unit tests for cookidoo-api."""
 
-from typing import Any, cast
+from typing import cast
 
 from dotenv import load_dotenv
 import pytest
@@ -23,6 +23,7 @@ from cookidoo_api.raw_types import (
     DescriptiveAssetJSON,
     RecipeDetailsJSON,
     RecipeJSON,
+    SearchResultJSON,
 )
 from cookidoo_api.types import CookidooLocalizationConfig, ThermomixMachineType
 from tests.responses import (
@@ -333,13 +334,16 @@ class TestCookidooSearchResultFromJson:
 
     def test_search_result_uses_data_key(self) -> None:
         """Search result reads from 'data' key when 'recipes' is missing."""
-        data = {
-            "data": [
-                {"id": "r1", "title": "Recipe One"},
-                {"id": "r2", "name": "Recipe Two"},
-            ],
-            "total": 2,
-        }
+        data = cast(
+            SearchResultJSON,
+            {
+                "data": [
+                    {"id": "r1", "title": "Recipe One"},
+                    {"id": "r2", "name": "Recipe Two"},
+                ],
+                "total": 2,
+            },
+        )
         result = cookidoo_search_result_from_json(data, None)
         assert len(result.recipes) == 2
         assert result.recipes[0].id == "r1"
@@ -350,29 +354,34 @@ class TestCookidooSearchResultFromJson:
 
     def test_search_result_skips_non_dict_items(self) -> None:
         """Non-dict items in recipes list are skipped; only dicts become hits."""
-        data = {
-            "recipes": [
-                {"id": "r1", "title": "A"},
-                "not-a-dict",
-                None,
-                {"id": "r2", "name": "B"},
-            ],
-        }
+        data = cast(
+            SearchResultJSON,
+            {
+                "recipes": [
+                    {"id": "r1", "title": "A"},
+                    "not-a-dict",
+                    None,
+                    {"id": "r2", "name": "B"},
+                ],
+            },
+        )
         result = cookidoo_search_result_from_json(data, None)
         assert len(result.recipes) == 2
         assert result.recipes[0].id == "r1"
         assert result.recipes[1].id == "r2"
-        # When total is missing, helper uses len(recipes_data)
-        assert result.total == 4
+        # When total is missing, helper uses len(hits) (filtered valid items)
+        assert result.total == 2
 
     def test_search_result_total_invalid_defaults_to_length(self) -> None:
         """When total is missing or not int, it defaults to len(recipes)."""
-        data: dict[str, Any] = {"recipes": [{"id": "r1", "title": "X"}]}
+        data = cast(SearchResultJSON, {"recipes": [{"id": "r1", "title": "X"}]})
         result = cookidoo_search_result_from_json(data, None)
         assert result.total == 1
 
-        data["total"] = "nope"
-        result = cookidoo_search_result_from_json(data, None)
+        data_invalid = cast(
+            SearchResultJSON, {"recipes": [{"id": "r1", "title": "X"}], "total": "nope"}
+        )
+        result = cookidoo_search_result_from_json(data_invalid, None)
         assert result.total == 1
 
     def test_search_result_with_descriptive_assets(self) -> None:
@@ -380,22 +389,25 @@ class TestCookidooSearchResultFromJson:
         localization = CookidooLocalizationConfig(
             country_code="ch", language="de-CH", url="https://cookidoo.ch"
         )
-        data = {
-            "recipes": [
-                {
-                    "id": "r123",
-                    "title": "Test",
-                    "descriptiveAssets": [
-                        {
-                            "square": "https://example.com/square.png",
-                            "portrait": "https://example.com/portrait.png",
-                            "landscape": "https://example.com/landscape.png",
-                        }
-                    ],
-                }
-            ],
-            "total": 1,
-        }
+        data = cast(
+            SearchResultJSON,
+            {
+                "recipes": [
+                    {
+                        "id": "r123",
+                        "title": "Test",
+                        "descriptiveAssets": [
+                            {
+                                "square": "https://example.com/square.png",
+                                "portrait": "https://example.com/portrait.png",
+                                "landscape": "https://example.com/landscape.png",
+                            }
+                        ],
+                    }
+                ],
+                "total": 1,
+            },
+        )
         result = cookidoo_search_result_from_json(data, localization)
         assert len(result.recipes) == 1
         assert result.recipes[0].thumbnail is not None


### PR DESCRIPTION
- Add search result dataclasses and export them through the public package API.
- Implement `search_recipes` with query normalization and parsing helper.
- Add unit tests covering search responses, filters, and error handling.

Hi! I added a helper that could perhaps be applied to the entire class to reduce repeated code. If you're okay with it, I can make a pull request with that. :D