### PR TITLE
Expose user id

### DIFF
--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -355,7 +355,7 @@ class Cookidoo:
                 r.raise_for_status()
 
                 try:
-                    return cookidoo_user_info_from_json((await r.json())["userInfo"])
+                    return cookidoo_user_info_from_json(await r.json())
                 except (JSONDecodeError, KeyError) as e:
                     _LOGGER.debug(
                         "Exception: Cannot get user info:\n%s",

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -13,6 +13,7 @@ from cookidoo_api.raw_types import (
     AdditionalItemJSON,
     CalendarDayJSON,
     CalenderDayRecipeJSON,
+    CommunityProfileJSON,
     CustomCollectionJSON,
     CustomRecipeJSON,
     DescriptiveAssetJSON,
@@ -23,7 +24,6 @@ from cookidoo_api.raw_types import (
     RecipeDetailsJSON,
     RecipeJSON,
     SubscriptionJSON,
-    UserInfoJSON,
 )
 from cookidoo_api.types import (
     CookidooAdditionalItem,
@@ -53,10 +53,12 @@ localization_file_path = os.path.join(os.path.dirname(__file__), "localization.j
 
 
 def cookidoo_user_info_from_json(
-    user_info: UserInfoJSON,
+    profile: CommunityProfileJSON,
 ) -> CookidooUserInfo:
-    """Convert a user info received from the API to a cookidoo user info."""
+    """Convert a community profile received from the API to a cookidoo user info."""
+    user_info = profile["userInfo"]
     return CookidooUserInfo(
+        id=profile["id"],
         username=user_info["username"],
         description=user_info.get("description"),
         picture=user_info["picture"],

--- a/cookidoo_api/raw_types.py
+++ b/cookidoo_api/raw_types.py
@@ -11,6 +11,13 @@ class UserInfoJSON(TypedDict):
     picture: str | None
 
 
+class CommunityProfileJSON(TypedDict):
+    """The json for the community profile response."""
+
+    id: str
+    userInfo: UserInfoJSON
+
+
 class SubscriptionJSON(TypedDict):
     """The json for a subscription in the API."""
 

--- a/cookidoo_api/types.py
+++ b/cookidoo_api/types.py
@@ -38,6 +38,7 @@ class CookidooConfig:
 class CookidooUserInfo:
     """A user info class."""
 
+    id: str
     username: str
     description: str | None
     picture: str | None

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -330,6 +330,7 @@ class TestGetUserInfo:
         )
 
         data = await cookidoo.get_user_info()
+        assert data.id == COOKIDOO_TEST_RESPONSE_USER_INFO["id"]
         assert (
             data.username == COOKIDOO_TEST_RESPONSE_USER_INFO["userInfo"]["username"]  # type: ignore[index]
         )


### PR DESCRIPTION
Follow up to 0.17.1, which does not expose this information anymore in the login return data.