### PR TITLE
Pin dependencies and upgrade pytest-asyncio

### DIFF
--- a/.github/workflows/well-known-discovery.yaml
+++ b/.github/workflows/well-known-discovery.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install requests
+          pip install requests~=2.32
 
       - name: Run discovery
         id: discovery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ authors = [
   { name = "Cyrill Raccaud", email = "cyrill.raccaud+pypi@gmail.com" },
 ]
 dependencies = [
-  "aiohttp",
-  "aiofiles",
-  "isodate",
+  "aiohttp~=3.13.0",
+  "aiofiles~=25.1.0",
+  "isodate~=0.7.2",
 ]
 requires-python = ">=3.12"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp~=3.13
+aiohttp~=3.13.0
 aiofiles~=25.1.0
 isodate~=0.7.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ python-dotenv>=1.2.2
 ruff~=0.15
 mkdocs-material==9.7.6
 mkdocstrings[python]==1.0.4
-pytest-asyncio>=1.3.0
+pytest-asyncio>=1.4.0
 pytest-cov>=7.1.0
 pytest>=9.0.3
 python-dotenv>=1.2.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest-asyncio>=1.3.0
+pytest-asyncio>=1.4.0
 pytest-cov>=7.1.0
 pytest>=9.0.3
 python-dotenv>=1.2.2


### PR DESCRIPTION
- Pin aiohttp~=3.13 (3.14 incompatible with aioresponses)
- Pin aiofiles~=25.1.0, isodate~=0.7.2
- Pin requests~=2.32 in well-known-discovery workflow
- Upgrade pytest-asyncio>=1.4.0