### PR TITLE
Fix Auto Label workflow failing on fork PRs

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -1,9 +1,6 @@
 name: Auto Label
 
 on:
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
Remove `pull_request` trigger and keep only `pull_request_target`, which has write permissions needed to label PRs from forks.

The workflow previously defined both triggers, causing two runs per PR — the `pull_request` one always fails on fork PRs due to insufficient permissions.