### PR TITLE
Add custom recipes listing API

### DIFF
--- a/cookidoo_api/const.py
+++ b/cookidoo_api/const.py
@@ -12,6 +12,10 @@ CIAM_LOGIN_SRV_URL: Final = (
 LOGIN_PATH: Final = "profile/{language}/login"
 LOGIN_REDIRECT: Final = "%2Ffoundation%2F{language}%2Ffor-you"
 RECIPE_PATH: Final = "recipes/recipe/{language}/{id}"
+CUSTOM_RECIPES_PATH: Final = "created-recipes/{language}"
+CUSTOM_RECIPES_PATH_ACCEPT: Final = (
+    "application/vnd.vorwerk.customer-recipe.full+json"
+)
 CUSTOM_RECIPE_PATH: Final = "created-recipes/{language}/{id}"
 ADD_CUSTOM_RECIPE_PATH: Final = "created-recipes/{language}"
 REMOVE_CUSTOM_RECIPE_PATH: Final = "created-recipes/{language}/{id}"

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -31,6 +31,8 @@ from cookidoo_api.const import (
     CUSTOM_COLLECTIONS_PATH,
     CUSTOM_COLLECTIONS_PATH_ACCEPT,
     CUSTOM_RECIPE_PATH,
+    CUSTOM_RECIPES_PATH,
+    CUSTOM_RECIPES_PATH_ACCEPT,
     DEFAULT_API_HEADERS,
     EDIT_ADDITIONAL_ITEMS_PATH,
     EDIT_OWNERSHIP_ADDITIONAL_ITEMS_PATH,
@@ -78,6 +80,7 @@ from cookidoo_api.raw_types import (
     CommunityProfileJSON,
     CustomCollectionJSON,
     CustomRecipeJSON,
+    CustomRecipesJSON,
     ItemJSON,
     ManagedCollectionJSON,
     PaginationJSON,
@@ -765,6 +768,34 @@ class Cookidoo:
                 cast(CustomRecipeJSON, result),
                 self._cfg.localization,
             ),
+        )
+
+    async def list_custom_recipes(self) -> list[CookidooCustomRecipe]:
+        """List custom recipes."""
+        url = self.api_endpoint / CUSTOM_RECIPES_PATH.format(
+            **self._cfg.localization.__dict__
+        )
+        result = self._ensure_mapping(
+            await self._request_json(
+                "get",
+                url,
+                "listing custom recipes",
+                headers={"ACCEPT": CUSTOM_RECIPES_PATH_ACCEPT},
+            ),
+            "listing custom recipes",
+        )
+        if not isinstance(result.get("items"), list):
+            raise CookidooParseException(
+                "Listing custom recipes failed during parsing of request response."
+            )
+
+        custom_recipes = cast(CustomRecipesJSON, result)
+        return self._parse_result(
+            "listing custom recipes",
+            lambda: [
+                cookidoo_custom_recipe_from_json(recipe, self._cfg.localization)
+                for recipe in custom_recipes["items"]
+            ],
         )
 
     async def add_custom_recipe_from(

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -1,5 +1,6 @@
 """Cookidoo API helpers."""
 
+from collections.abc import Sequence
 import json
 import logging
 import os
@@ -15,7 +16,9 @@ from cookidoo_api.raw_types import (
     CalenderDayRecipeJSON,
     CommunityProfileJSON,
     CustomCollectionJSON,
+    CustomRecipeContentJSON,
     CustomRecipeJSON,
+    CustomRecipeTextJSON,
     DescriptiveAssetJSON,
     IngredientJSON,
     ItemJSON,
@@ -387,32 +390,54 @@ def cookidoo_custom_recipe_from_json(
     localization: CookidooLocalizationConfig | None = None,
 ) -> CookidooCustomRecipe:
     """Convert a custom recipe received from the API to a cookidoo custom recipe."""
-    total_time = isodate.parse_duration(
-        recipe["recipeContent"]["totalTime"]
-    ).total_seconds()
-    active_time = isodate.parse_duration(
-        recipe["recipeContent"]["prepTime"]
-    ).total_seconds()
+    def _duration_to_seconds(value: str | int | float | None) -> int:
+        if value is None:
+            return 0
+
+        if isinstance(value, int | float):
+            return int(value)
+
+        duration = isodate.parse_duration(value).total_seconds()
+        return int(duration) if isinstance(duration, float) else 0
+
+    def _extract_text_list(
+        value: Sequence[str | CustomRecipeTextJSON],
+    ) -> list[str]:
+        return [item["text"] if isinstance(item, dict) else item for item in value]
+
+    recipe_content: CustomRecipeContentJSON = recipe["recipeContent"]
+    total_time = _duration_to_seconds(recipe_content.get("totalTime"))
+    active_time = _duration_to_seconds(recipe_content.get("prepTime"))
 
     thumbnail: str | None = None
     image: str | None = None
 
-    recipe_content = recipe["recipeContent"]
     image = recipe_content.get("image", None)
     if image:
         thumbnail, image = _process_image_url(image)
 
     url = _construct_recipe_url(localization, recipe["recipeId"], "created-recipes")
+    recipe_yield = (
+        recipe_content.get("recipeYield")
+        or recipe_content.get("yield")
+        or {"value": 0, "unitText": ""}
+    )
 
     return CookidooCustomRecipe(
         id=recipe["recipeId"],
-        name=recipe["recipeContent"]["name"],
-        ingredients=recipe["recipeContent"]["recipeIngredient"],
-        instructions=recipe["recipeContent"]["recipeInstructions"],
-        serving_size=recipe["recipeContent"]["recipeYield"]["value"],
-        total_time=int(total_time) if isinstance(total_time, float) else 0,
-        active_time=int(active_time) if isinstance(active_time, float) else 0,
-        tools=recipe["recipeContent"]["tool"],
+        name=recipe_content["name"],
+        ingredients=_extract_text_list(
+            recipe_content.get("recipeIngredient")
+            or recipe_content.get("ingredients", [])
+        ),
+        instructions=_extract_text_list(
+            recipe_content.get("recipeInstructions")
+            or recipe_content.get("instructions", [])
+        ),
+        serving_size=recipe_yield["value"],
+        total_time=total_time,
+        active_time=active_time,
+        tools=recipe_content.get("tool") or recipe_content.get("tools", []),
         thumbnail=thumbnail,
         image=image,
         url=url,

--- a/cookidoo_api/raw_types.py
+++ b/cookidoo_api/raw_types.py
@@ -1,6 +1,6 @@
 """Cookidoo API raw json types."""
 
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, NotRequired, Required, TypedDict
 
 
 class UserInfoJSON(TypedDict):
@@ -205,25 +205,44 @@ class CustomRecipeYieldJSON(TypedDict):
     unitText: str
 
 
-class CustomRecipeContentJSON(TypedDict):
-    """The json for a custom recipe content in the API."""
+class CustomRecipeTextJSON(TypedDict):
+    """A text item in a custom recipe list response."""
 
-    name: str
-    totalTime: str
-    prepTime: str
-    tool: list[str]
-    recipeYield: CustomRecipeYieldJSON
-    recipeIngredient: list[str]
-    recipeInstructions: list[str]
-    image: str | None
+    text: str
+
+
+CustomRecipeContentJSON = TypedDict(
+    "CustomRecipeContentJSON",
+    {
+        "name": Required[str],
+        "totalTime": str | int | float,
+        "prepTime": str | int | float,
+        "tool": list[str],
+        "tools": list[str],
+        "recipeYield": CustomRecipeYieldJSON,
+        "yield": CustomRecipeYieldJSON,
+        "recipeIngredient": list[str | CustomRecipeTextJSON],
+        "ingredients": list[str | CustomRecipeTextJSON],
+        "recipeInstructions": list[str | CustomRecipeTextJSON],
+        "instructions": list[str | CustomRecipeTextJSON],
+        "image": str | None,
+    },
+    total=False,
+)
 
 
 class CustomRecipeJSON(TypedDict):
     """The json for a custom recipe in the API."""
 
     recipeId: str
-    title: str
+    title: NotRequired[str]
     recipeContent: CustomRecipeContentJSON
+
+
+class CustomRecipesJSON(TypedDict):
+    """The json for a custom recipe list response."""
+
+    items: list[CustomRecipeJSON]
 
 
 class ChapterRecipeJSON(TypedDict):

--- a/smoke_test/test_2_methods.py
+++ b/smoke_test/test_2_methods.py
@@ -59,6 +59,15 @@ class TestMethods:
             recipe = result.recipes[0]
             assert hasattr(recipe, "id") and hasattr(recipe, "name")
 
+    async def test_cookidoo_list_custom_recipes(self, cookidoo: Cookidoo) -> None:
+        """Test cookidoo list custom recipes."""
+        recipes = await cookidoo.list_custom_recipes()
+
+        assert isinstance(recipes, list)
+        for recipe in recipes:
+            assert recipe.id
+            assert recipe.name
+
     async def test_cookidoo_shopping_list_recipe_and_ingredients(
         self, cookidoo: Cookidoo
     ) -> None:

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -342,6 +342,37 @@ COOKIDOO_TEST_RESPONSE_GET_CUSTOM_RECIPE = {
     },
 }
 
+COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES: Final = {
+    "meta": {"recipeLimit": 150, "recipeLimitThreshold": 5},
+    "items": [
+        {
+            "recipeId": "01K2CTJ9Y1BABRG5MXK44CFZS4",
+            "authorId": "2d336b56-6c23-49bb-9543-5bdf0344eedf",
+            "modifiedAt": "2025-08-11T15:04:16.577Z",
+            "createdAt": "2025-08-11T15:04:16.577Z",
+            "status": "ACTIVE",
+            "workStatus": "PRIVATE",
+            "recipeContent": {
+                "name": "Vongole alla marinara",
+                "image": "https://assets.tmecosys.com/image/upload/{transformation}/img/recipe/ras/Assets/29F42E5A-098A-46BC-87C5-59CF7C81E44D/Derivates/43ADC698-B45F-41E2-A479-FA5BC32702C6",
+                "isBasedOn": "https://cookidoo.ch/recipes/recipe/en/r166987",
+                "prepTime": 600,
+                "totalTime": 1800,
+                "tools": ["TM7", "TM6", "TM5"],
+                "yield": {"value": 6, "unitText": "portion"},
+                "ingredients": [
+                    {"type": "INGREDIENT", "text": "130 g di cipolla"},
+                    {"type": "INGREDIENT", "text": "65 g di olio extravergine di oliva"},
+                ],
+                "instructions": [
+                    {"type": "STEP", "text": "Mettere nel boccale le cipolle."},
+                    {"type": "STEP", "text": "Servire subito."},
+                ],
+            },
+        }
+    ],
+}
+
 COOKIDOO_TEST_RESPONSE_ADD_CUSTOM_RECIPE = {
     "recipeId": "01K2CTJ9Y1BABRG5MXK44CFZS4",
     "authorId": "2d336b56-6c23-49bb-9543-5bdf0344eedf",

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -48,6 +48,7 @@ from tests.responses import (
     COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS,
     COOKIDOO_TEST_RESPONSE_GET_SHOPPING_LIST_RECIPES,
     COOKIDOO_TEST_RESPONSE_INACTIVE_SUBSCRIPTION,
+    COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES,
     COOKIDOO_TEST_RESPONSE_REMOVE_CUSTOM_RECIPE_FROM_CALENDAR,
     COOKIDOO_TEST_RESPONSE_REMOVE_RECIPE_FROM_CALENDAR,
     COOKIDOO_TEST_RESPONSE_REMOVE_RECIPE_FROM_CUSTOM_COLLECTION,
@@ -969,6 +970,100 @@ class TestGetCustomRecipe:
 
         with pytest.raises(exception):
             await cookidoo.get_custom_recipe("01K2CVHD1DXG1PVETNVV3JPKWW")
+
+
+class TestListCustomRecipes:
+    """Tests for list_custom_recipes method."""
+
+    async def test_list_custom_recipes(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test for list_custom_recipes."""
+        mocked.get(
+            "https://cookidoo.ch/created-recipes/de-CH",
+            payload=COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES,
+            status=HTTPStatus.OK,
+        )
+
+        data = await cookidoo.list_custom_recipes()
+
+        assert len(data) == 1
+        assert data[0].id == "01K2CTJ9Y1BABRG5MXK44CFZS4"
+        assert data[0].name == "Vongole alla marinara"
+        assert data[0].active_time == 600
+        assert data[0].total_time == 1800
+        assert data[0].ingredients == [
+            "130 g di cipolla",
+            "65 g di olio extravergine di oliva",
+        ]
+
+    async def test_list_custom_recipes_empty(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test for list_custom_recipes with no recipes."""
+        mocked.get(
+            "https://cookidoo.ch/created-recipes/de-CH",
+            payload={"items": []},
+            status=HTTPStatus.OK,
+        )
+
+        data = await cookidoo.list_custom_recipes()
+
+        assert data == []
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            TimeoutError,
+            ClientError,
+        ],
+    )
+    async def test_request_exception(
+        self, mocked: aioresponses, cookidoo: Cookidoo, exception: Exception
+    ) -> None:
+        """Test request exceptions."""
+        mocked.get(
+            "https://cookidoo.ch/created-recipes/de-CH",
+            exception=exception,
+        )
+
+        with pytest.raises(CookidooRequestException):
+            await cookidoo.list_custom_recipes()
+
+    async def test_unauthorized(self, mocked: aioresponses, cookidoo: Cookidoo) -> None:
+        """Test unauthorized exception."""
+        mocked.get(
+            "https://cookidoo.ch/created-recipes/de-CH",
+            status=HTTPStatus.UNAUTHORIZED,
+            payload={"error_description": ""},
+        )
+
+        with pytest.raises(CookidooAuthException):
+            await cookidoo.list_custom_recipes()
+
+    @pytest.mark.parametrize(
+        ("payload", "exception"),
+        [
+            ({}, CookidooParseException),
+            ({"items": None}, CookidooParseException),
+        ],
+    )
+    async def test_parse_exception(
+        self,
+        mocked: aioresponses,
+        cookidoo: Cookidoo,
+        payload: dict[str, object],
+        exception: type[CookidooException],
+    ) -> None:
+        """Test parse exceptions."""
+        mocked.get(
+            "https://cookidoo.ch/created-recipes/de-CH",
+            status=HTTPStatus.OK,
+            payload=payload,
+        )
+
+        with pytest.raises(exception):
+            await cookidoo.list_custom_recipes()
 
 
 class TestAddCustomRecipe:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -266,7 +266,7 @@ class TestRecipeImagesAndUrls:
         """Test cookidoo_custom_recipe_from_json handles list response format."""
         recipe_json = cast(
             CustomRecipeJSON,
-            COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES["items"][0],
+            COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES["items"][0],  # type: ignore[index]
         )
         localization = CookidooLocalizationConfig(
             country_code="ch", language="de-CH", url="https://cookidoo.ch"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -31,6 +31,7 @@ from tests.responses import (
     COOKIDOO_TEST_RESPONSE_GET_CUSTOM_RECIPE,
     COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS,
     COOKIDOO_TEST_RESPONSE_GET_SHOPPING_LIST_RECIPES,
+    COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES,
 )
 
 load_dotenv()
@@ -260,6 +261,56 @@ class TestRecipeImagesAndUrls:
             result.url
             == "https://cookidoo.ch/created-recipes/de-CH/01K2CVHD1DXG1PVETNVV3JPKWW"
         )
+
+    def test_cookidoo_custom_recipe_from_json_with_list_format(self) -> None:
+        """Test cookidoo_custom_recipe_from_json handles list response format."""
+        recipe_json = cast(
+            CustomRecipeJSON,
+            COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES["items"][0],
+        )
+        localization = CookidooLocalizationConfig(
+            country_code="ch", language="de-CH", url="https://cookidoo.ch"
+        )
+
+        result = cookidoo_custom_recipe_from_json(recipe_json, localization)
+
+        assert result.id == "01K2CTJ9Y1BABRG5MXK44CFZS4"
+        assert result.name == "Vongole alla marinara"
+        assert result.ingredients == [
+            "130 g di cipolla",
+            "65 g di olio extravergine di oliva",
+        ]
+        assert result.instructions == [
+            "Mettere nel boccale le cipolle.",
+            "Servire subito.",
+        ]
+        assert result.tools == ["TM7", "TM6", "TM5"]
+        assert result.active_time == 600
+        assert result.total_time == 1800
+        assert result.serving_size == 6
+
+    def test_cookidoo_custom_recipe_from_json_with_missing_optional_values(
+        self,
+    ) -> None:
+        """Test list response parsing when optional values are missing."""
+        recipe_json = cast(
+            CustomRecipeJSON,
+            {
+                "recipeId": "empty-recipe",
+                "recipeContent": {
+                    "name": "Empty recipe",
+                    "ingredients": [],
+                    "instructions": [],
+                },
+            },
+        )
+
+        result = cookidoo_custom_recipe_from_json(recipe_json)
+
+        assert result.total_time == 0
+        assert result.active_time == 0
+        assert result.serving_size == 0
+        assert result.tools == []
 
     def test_cookidoo_calendar_day_from_json_with_images(self) -> None:
         """Test cookidoo_calendar_day_from_json extracts images correctly."""


### PR DESCRIPTION
## Context

Cookidoo exposes methods to fetch and manage individual custom recipes, but the client does not currently provide a way to retrieve the user's complete custom recipe list.

The custom recipe listing endpoint also returns recipe content in a slightly different shape from the individual recipe endpoint, so the existing parser needs to understand both representations.

## Objective

The goal of this PR is to add a focused `list_custom_recipes()` API while preserving the behavior of the existing custom recipe methods.

## What changed

### List custom recipes

- Added `list_custom_recipes()` to retrieve all custom recipes from `created-recipes/{language}`.
- Added the custom recipe collection media type required by the listing endpoint.
- Routed the request through the shared `_request_json` helper so authorization failures, request errors, timeouts, malformed responses, and JSON parsing remain consistent with the rest of the client.
- Added response-shape validation before parsing the returned items.

### List response parsing

- Added typed structures for the custom recipe list response and its text items.
- Updated the existing custom recipe parser to support the field names returned by the list endpoint:
  - numeric or ISO-8601 durations
  - `tool` or `tools`
  - `recipeYield` or `yield`
  - `recipeIngredient` or `ingredients`
  - `recipeInstructions` or `instructions`
- Normalized ingredient and instruction objects containing `text` into the existing `list[str]` public representation.
- Added safe zero defaults when optional times or yield data are missing.
- Kept the parser fully typed without introducing `Any`.

### Tests

- Added unit tests for successful listing, empty lists, authorization failures, request exceptions, and malformed responses.
- Added parser coverage for the custom recipe list response format.
- Added a read-only smoke test against the real Cookidoo listing endpoint.

## Behavioral notes

- This PR only adds custom recipe listing support. It does not add custom recipe creation or editing APIs.
- `list_custom_recipes()` returns `list[CookidooCustomRecipe]`.
- Existing individual custom recipe methods retain their current behavior.
- The public `CookidooCustomRecipe` representation remains unchanged.

## Validation

- `.venv/bin/python -m pytest -q --cov-config=pyproject.toml --cov=cookidoo_api --cov-branch --cov-report=term-missing --cov-fail-under=100`
  - `270 passed`
  - statements: `849/849`
  - branches: `112/112`
  - total coverage: `100.00%`
- `.venv/bin/python -m pytest -q smoke_test/test_2_methods.py::TestMethods::test_cookidoo_list_custom_recipes`
  - `1 passed` against the real Cookidoo endpoint
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy cookidoo_api`
