### PR TITLE
Make search_recipes filter params keyword-only

### DIFF
--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -598,6 +598,7 @@ class Cookidoo:
     async def search_recipes(
         self,
         query: str | None = None,
+        *,
         locale: str | None = None,
         accessories: str | list[str] | None = None,
         languages: str | list[str] | None = None,


### PR DESCRIPTION
## Context

The ruff 0.16 upgrade enables the `PLR0917` rule (too many positional arguments), which now flags `search_recipes()` since it has 17 positional parameters.

## Change

Add a bare `*` after `query` in `search_recipes()` so all filter parameters become keyword-only. `query` remains positional since it's the primary/most commonly used argument.

## Compatibility

All existing call sites (tests, smoke tests) already pass `query` positionally and every other parameter as a keyword argument, so this is a no-op behaviorally for current usage. It would only break external callers passing e.g. `locale` positionally, which is unlikely given the large number of parameters.

## Validation

- `ruff check .` — passes (PLR0917 resolved)
- `pytest` — 270 passed
- `mypy cookidoo_api tests smoke_test` — clean