### PR TITLE
Send a browser-like User-Agent on login requests

### DIFF
--- a/cookidoo_api/const.py
+++ b/cookidoo_api/const.py
@@ -6,6 +6,20 @@ DEFAULT_API_HEADERS: Final = {
     "ACCEPT": "application/json",
 }
 
+# A browser-like User-Agent for the login flow requests only. The login
+# flow is served behind Cloudflare and clients without a recognizable
+# browser User-Agent (e.g. Home Assistant's default "Home Assistant/x.y
+# aiohttp/x.y Python/x.y") are more likely to be flagged as bots, causing
+# intermittent 403s. This does not touch the caller's session defaults,
+# it is only sent with the login requests below.
+# See https://github.com/miaucl/cookidoo-api/issues/230
+LOGIN_HEADERS: Final = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+    ),
+}
+
 CIAM_LOGIN_SRV_URL: Final = (
     "https://ciam.prod.cookidoo.vorwerk-digital.com/login-srv/login"
 )
@@ -13,9 +27,7 @@ LOGIN_PATH: Final = "profile/{language}/login"
 LOGIN_REDIRECT: Final = "%2Ffoundation%2F{language}%2Ffor-you"
 RECIPE_PATH: Final = "recipes/recipe/{language}/{id}"
 CUSTOM_RECIPES_PATH: Final = "created-recipes/{language}"
-CUSTOM_RECIPES_PATH_ACCEPT: Final = (
-    "application/vnd.vorwerk.customer-recipe.full+json"
-)
+CUSTOM_RECIPES_PATH_ACCEPT: Final = "application/vnd.vorwerk.customer-recipe.full+json"
 CUSTOM_RECIPE_PATH: Final = "created-recipes/{language}/{id}"
 ADD_CUSTOM_RECIPE_PATH: Final = "created-recipes/{language}"
 REMOVE_CUSTOM_RECIPE_PATH: Final = "created-recipes/{language}/{id}"

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -38,6 +38,7 @@ from cookidoo_api.const import (
     EDIT_OWNERSHIP_ADDITIONAL_ITEMS_PATH,
     EDIT_OWNERSHIP_INGREDIENT_ITEMS_PATH,
     INGREDIENT_ITEMS_PATH,
+    LOGIN_HEADERS,
     LOGIN_PATH,
     LOGIN_REDIRECT,
     MANAGED_COLLECTIONS_PATH,
@@ -336,6 +337,12 @@ class Cookidoo:
         After login, the session's cookie jar contains the authentication
         cookies and all subsequent API calls are authenticated automatically.
 
+        The login requests are sent with a browser-like ``User-Agent``
+        (request-scoped only, the session's own defaults are left untouched)
+        since the login flow is served behind Cloudflare, which is more
+        likely to challenge/block requests carrying a non-browser
+        User-Agent (e.g. a generic HTTP client's default).
+
         Raises
         ------
         CookidooRequestException
@@ -356,7 +363,9 @@ class Cookidoo:
 
         try:
             # Step 1: Follow redirect chain to reach the CIAM login page
-            async with self._session.get(login_url, allow_redirects=True) as resp:
+            async with self._session.get(
+                login_url, allow_redirects=True, headers=LOGIN_HEADERS
+            ) as resp:
                 self._check_login_page_status(resp.status)
                 login_html = await resp.text()
 
@@ -373,6 +382,7 @@ class Cookidoo:
                 CIAM_LOGIN_SRV_URL,
                 data=login_data,
                 allow_redirects=True,
+                headers=LOGIN_HEADERS,
             ) as resp:
                 _LOGGER.debug(
                     "Login POST completed, final URL: %s (status: %s)",


### PR DESCRIPTION
## Context

Fixes/mitigates #230 (and likely home-assistant/core#173527).

The login flow (`GET` the login page, `POST` credentials to CIAM) is served behind Cloudflare. A reporter on #230 captured the actual 403 response body — it's Cloudflare's `Just a moment...` challenge page, not an app-level auth rejection. Clients without a recognizable browser `User-Agent` are more likely to be flagged/challenged, causing intermittent failures.

This is especially relevant for Home Assistant: its shared `aiohttp` session's default `User-Agent` is `Home Assistant/x.y aiohttp/x.y Python/x.y` — a non-browser fingerprint sent identically by every installation performing this exact login flow.

## Change

- Added a `LOGIN_HEADERS` constant (browser-like `User-Agent`) in `const.py`.
- Applied it **only** to the two login requests (`GET` login page, `POST` to CIAM), passed as request-scoped `headers=` — the caller's session defaults are left untouched.
- This matches Home Assistant's own documented pattern (`aiohttp_client.py`): the shared session must always identify as Home Assistant, but a dependency may override the `User-Agent` per-request if the target API needs it.

## Caveats

Not a guaranteed fix — if Cloudflare is issuing a full JS challenge (rather than a heuristic bot/rate-limit score) for every request, no header change will get past it. But the reported failures are intermittent (works, breaks after a restart, self-heals after ~a day), which is more consistent with a heuristic score than a hard block, so this is a low-risk thing to try first.

Also raised a companion plan for reducing re-login frequency (via the existing `save_cookies()`/`load_cookies()`) on the Home Assistant integration side, tracked in home-assistant/core#173527.

## Validation

- `pytest` — 270 passed, 100% coverage
- `mypy cookidoo_api tests smoke_test` — clean
- `ruff check .` / `ruff format` — clean (aside from the pre-existing, unrelated `PLR0917` fixed separately in #239)