### PR TITLE
feat: add remote monitoring (device management)

### DIFF
--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -12,7 +12,12 @@ from .exceptions import (
     CookidooResponseException,
     CookidooUnavailableException,
 )
-from .helpers import get_country_options, get_language_options, get_localization_options
+from .helpers import (
+    cooking_activity_from_push,
+    get_country_options,
+    get_language_options,
+    get_localization_options,
+)
 from .types import (
     CookidooAdditionalItem,
     CookidooAuthData,
@@ -21,6 +26,8 @@ from .types import (
     CookidooChapterRecipe,
     CookidooCollection,
     CookidooConfig,
+    CookidooCookingActivity,
+    CookidooCookState,
     CookidooDevice,
     CookidooIngredient,
     CookidooIngredientItem,
@@ -48,6 +55,9 @@ __all__ = [
     "CookidooItem",
     "CookidooDevice",
     "CookidooAuthData",
+    "CookidooCookingActivity",
+    "CookidooCookState",
+    "cooking_activity_from_push",
     "CookidooAdditionalItem",
     "CookidooIngredientItem",
     "CookidooShoppingRecipe",

--- a/cookidoo_api/const.py
+++ b/cookidoo_api/const.py
@@ -78,6 +78,26 @@ DEVICES_PATH: Final = "customer-devices/api/my-devices/versions"
 
 SEARCH_PATH: Final = "search/{locale}"
 
+# --- Remote monitoring (device management) --------------------------------
+# The remote-monitoring (RMI) endpoints live on a dedicated IoT backend that is
+# discovered from the mobile home document -> rmi-config sub-document. Reaching
+# them requires the OAuth2 bearer token (the previous cookie session was refused).
+MOBILE_HOME_PATH: Final = ".well-known/mobile-home"
+HAL_ACCEPT: Final = (
+    "application/vnd.vorwerk.tmde2.rhd.mobile.hal+json, application/hal+json"
+)
+# The RMI write endpoints require this API-version header.
+RMI_API_VERSION: Final = "2026-06-01"
+
+REL_RMI_CONFIG: Final = "tmde2:rmi-config"
+RMI_REGISTER_TOKEN: Final = "rmi:register-token"
+RMI_UNREGISTER: Final = "rmi:unregister"
+RMI_DEVICES: Final = "rmi:devices"
+
+# Fields for the push-token registration payload.
+PUSH_BUNDLE_ID: Final = "com.vorwerk.cookidoo"
+PUSH_PLATFORM: Final = "AN"  # Android; the value the app sends
+
 CUSTOM_COLLECTIONS_PATH: Final = "organize/{language}/api/custom-list"
 CUSTOM_COLLECTIONS_PATH_ACCEPT: Final = (
     "application/vnd.vorwerk.organize.custom-list.mobile+json"

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -27,10 +27,19 @@ from cookidoo_api.const import (
     CUSTOM_COLLECTIONS_PATH_ACCEPT,
     CUSTOM_RECIPES_PATH_ACCEPT,
     DEFAULT_API_HEADERS,
+    HAL_ACCEPT,
     LOGIN_HEADERS,
     MANAGED_COLLECTIONS_PATH_ACCEPT,
+    MOBILE_HOME_PATH,
     OAUTH_SCOPE,
     OIDC_DISCOVERY_URL,
+    PUSH_BUNDLE_ID,
+    PUSH_PLATFORM,
+    REL_RMI_CONFIG,
+    RMI_API_VERSION,
+    RMI_DEVICES,
+    RMI_REGISTER_TOKEN,
+    RMI_UNREGISTER,
     TOKEN_EXPIRY_MARGIN_S,
 )
 from cookidoo_api.exceptions import (
@@ -105,6 +114,7 @@ class Cookidoo:
     _refresh_token: str | None
     _expires_at: float
     _oidc: dict[str, str] | None
+    _rmi_links: dict[str, str] | None
 
     def __init__(
         self,
@@ -133,6 +143,7 @@ class Cookidoo:
         self._refresh_token = None
         self._expires_at = 0.0
         self._oidc = None
+        self._rmi_links = None
 
     @property
     def localization(self) -> CookidooLocalizationConfig:
@@ -840,6 +851,181 @@ class Cookidoo:
         return self._parse_result(
             "loading devices",
             lambda: [cookidoo_device_from_json(cast(str, model)) for model in models],
+        )
+
+    async def _resolve_rmi_links(self) -> dict[str, str]:
+        """Resolve and cache the remote-monitoring endpoint links.
+
+        Walks the mobile home document to the ``rmi-config`` sub-document and
+        returns its ``{rel: href}`` map (``rmi:register-token``, ``rmi:devices``,
+        ``rmi:unregister``, ...).
+        """
+        if self._rmi_links is not None:
+            return self._rmi_links
+
+        hal_headers = {"ACCEPT": HAL_ACCEPT}
+        home = self._ensure_mapping(
+            await self._request_json(
+                "get",
+                self.api_endpoint / MOBILE_HOME_PATH,
+                "resolving remote monitoring",
+                headers=hal_headers,
+            ),
+            "resolving remote monitoring",
+        )
+        rmi_config_url = self._hal_link(home, REL_RMI_CONFIG)
+        if rmi_config_url is None:
+            raise CookidooParseException(
+                "Resolving remote monitoring failed: rmi-config link missing."
+            )
+        rmi_home = self._ensure_mapping(
+            await self._request_json(
+                "get",
+                URL(rmi_config_url),
+                "resolving remote monitoring",
+                headers=hal_headers,
+            ),
+            "resolving remote monitoring",
+        )
+        links_obj = rmi_home.get("_links")
+        if not isinstance(links_obj, Mapping):
+            raise CookidooParseException(
+                "Resolving remote monitoring failed during parsing of request response."
+            )
+        links: dict[str, str] = {}
+        for rel, value in links_obj.items():
+            if isinstance(value, str):
+                links[rel] = value
+            elif isinstance(value, Mapping) and isinstance(value.get("href"), str):
+                links[rel] = cast(str, value["href"])
+        self._rmi_links = links
+        return links
+
+    @staticmethod
+    def _hal_link(doc: Mapping[str, object], rel: str) -> str | None:
+        """Extract a HAL link href for ``rel`` from a document's ``_links``."""
+        links = doc.get("_links")
+        if not isinstance(links, Mapping):
+            return None
+        value = links.get(rel)
+        if isinstance(value, str):
+            return value
+        if isinstance(value, Mapping) and isinstance(value.get("href"), str):
+            return cast(str, value["href"])
+        return None
+
+    async def get_monitored_device_ids(self) -> list[str]:
+        """Get the appliance IDs currently available for remote monitoring.
+
+        Note this is distinct from :meth:`get_devices` (all paired appliances):
+        an appliance only appears here while it is online/reachable for
+        monitoring, and the identifier is the opaque remote-monitoring device id.
+
+        Returns
+        -------
+        list[str]
+            The remote-monitoring device ids (empty when none are available).
+
+        Raises
+        ------
+        CookidooAuthException
+            When the access token is not valid anymore
+        CookidooRequestException
+            If the request fails.
+        CookidooParseException
+            If the parsing of the request response fails.
+
+        """
+        links = await self._resolve_rmi_links()
+        url = links.get(RMI_DEVICES)
+        if url is None:
+            raise CookidooParseException("rmi:devices link missing.")
+        devices = self._ensure_sequence(
+            await self._request_json(
+                "get", URL(url.split("{")[0]), "loading monitored devices"
+            ),
+            "loading monitored devices",
+        )
+        return self._parse_result(
+            "loading monitored devices",
+            lambda: [
+                cast(str, cast(Mapping[str, object], device)["deviceId"])
+                for device in devices
+            ],
+        )
+
+    async def register_push_token(self, push_token: str, mobile_app_id: str) -> None:
+        """Register a push token to receive remote-monitoring cook-state updates.
+
+        Appliance state is delivered as a Firebase Cloud Messaging data message
+        to the registered token; obtaining the token and receiving the messages
+        is the caller's responsibility. Decode received payloads with
+        :func:`cookidoo_api.cooking_activity_from_push`.
+
+        Parameters
+        ----------
+        push_token
+            The FCM registration token to deliver updates to.
+        mobile_app_id
+            A stable per-installation identifier for this client.
+
+        Raises
+        ------
+        CookidooAuthException
+            When the access token is not valid anymore
+        CookidooRequestException
+            If the request fails.
+        CookidooParseException
+            If the parsing of the request response fails.
+
+        """
+        links = await self._resolve_rmi_links()
+        url = links.get(RMI_REGISTER_TOKEN)
+        if url is None:
+            raise CookidooParseException("rmi:register-token link missing.")
+        await self._request_json(
+            "post",
+            URL(url),
+            "registering push token",
+            json={
+                "token": push_token,
+                "bundleId": PUSH_BUNDLE_ID,
+                "platform": PUSH_PLATFORM,
+                "mobileAppId": mobile_app_id,
+            },
+            headers={"rmi-api-version": RMI_API_VERSION},
+            parse_response=False,
+        )
+
+    async def unregister_push_token(self, push_token: str) -> None:
+        """Unregister a previously registered push token.
+
+        Parameters
+        ----------
+        push_token
+            The FCM registration token to stop delivering updates to.
+
+        Raises
+        ------
+        CookidooAuthException
+            When the access token is not valid anymore
+        CookidooRequestException
+            If the request fails.
+        CookidooParseException
+            If the parsing of the request response fails.
+
+        """
+        links = await self._resolve_rmi_links()
+        url = links.get(RMI_UNREGISTER)
+        if url is None:
+            raise CookidooParseException("rmi:unregister link missing.")
+        await self._request_json(
+            "delete",
+            URL(url),
+            "unregistering push token",
+            json={"tokens": [push_token]},
+            headers={"rmi-api-version": RMI_API_VERSION},
+            parse_response=False,
         )
 
     async def get_recipe_details(self, id: str) -> CookidooShoppingRecipeDetails:

--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -1,6 +1,7 @@
 """Cookidoo API helpers."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 import json
 import logging
 import os
@@ -38,6 +39,8 @@ from cookidoo_api.types import (
     CookidooChapter,
     CookidooChapterRecipe,
     CookidooCollection,
+    CookidooCookingActivity,
+    CookidooCookState,
     CookidooCustomRecipe,
     CookidooDevice,
     CookidooIngredient,
@@ -123,6 +126,107 @@ def cookidoo_device_from_json(model: str) -> CookidooDevice:
     The devices endpoint returns bare machine-type strings (e.g. ``"TM7"``).
     """
     return CookidooDevice(type=ThermomixMachineType(model))
+
+
+def _push_timestamp(value: object) -> datetime | None:
+    """Parse a push timestamp (ISO-8601 or epoch millis/seconds)."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        seconds = value / 1000.0 if value > 1e12 else float(value)
+        return datetime.fromtimestamp(seconds, tz=UTC)
+    if isinstance(value, str):
+        text = value.strip()
+        if text.isdigit():
+            return _push_timestamp(int(text))
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _push_number(value: object) -> float | None:
+    """Parse a numeric display field; the app uses ``"---"`` for 'no value'."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text or set(text) <= {"-", "–", "—"}:
+        return None
+    try:
+        return float(text.replace(",", "."))
+    except ValueError:
+        return None
+
+
+def _push_bool(value: object) -> bool:
+    """Parse a boolean; push values are strings, so ``"false"`` must be falsy."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes")
+    return bool(value)
+
+
+def cooking_activity_from_push(
+    data: Mapping[str, object],
+) -> CookidooCookingActivity:
+    """Convert a remote-monitoring push payload into a cooking activity.
+
+    Appliance state is delivered out of band (a Firebase Cloud Messaging data
+    message) rather than as an HTTP response, so consumers receive it via their
+    own push channel and decode it here. Both the on-the-wire field names
+    (``leadingText``/``trailingText``/``completedDate``/``staleDate``/…) and the
+    app's parsed names are accepted.
+    """
+
+    def first(*keys: str) -> object:
+        for key in keys:
+            if key in data and data[key] is not None:
+                return data[key]
+        return None
+
+    remaining_raw = first("remainingDuration")
+    remaining: int | None = None
+    if isinstance(remaining_raw, (int, str)):
+        try:
+            remaining = int(remaining_raw)
+        except ValueError:
+            remaining = None
+    completed_at = _push_timestamp(first("completedDate", "completedTimestamp"))
+    end_at = _push_timestamp(first("endTimestamp"))
+    # The wire payload has no remainingDuration; derive it from the finish time.
+    if remaining is None:
+        finish = completed_at or end_at
+        if finish is not None:
+            remaining = max(0, int((finish - datetime.now(UTC)).total_seconds()))
+
+    state_raw = first("state")
+    state = CookidooCookState(str(state_raw).upper()) if state_raw is not None else None
+    recipe_type = first("recipeType")
+
+    return CookidooCookingActivity(
+        device_id=str(first("deviceId") or ""),
+        cooking_activity_id=cast("str | None", first("cookingActivityId")),
+        state=state,
+        recipe_id=cast("str | None", first("recipeId")),
+        recipe_type=str(recipe_type).upper() if recipe_type is not None else None,
+        recipe_name=cast(
+            "str | None", first("leadingText", "leadingInfoText", "infoText")
+        ),
+        step=cast("str | None", first("trailingText", "trailingInfoText")),
+        remaining_seconds=remaining,
+        is_time_estimated=_push_bool(data.get("isTimeEstimated", False)),
+        current_temperature=_push_number(first("primaryInfo")),
+        target_temperature=_push_number(first("secondaryInfo")),
+        message_title=cast("str | None", first("messageTitle")),
+        message_body=cast("str | None", first("messageBody")),
+        message_criticality=cast("str | None", first("messageCriticality")),
+        completed_at=completed_at,
+        stale_at=_push_timestamp(first("staleDate", "staleTimestamp")),
+    )
 
 
 def cookidoo_collection_from_json(

--- a/cookidoo_api/types.py
+++ b/cookidoo_api/types.py
@@ -1,6 +1,7 @@
 """Cookidoo API types."""
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 
 from cookidoo_api.const import OAUTH_CLIENT_ID, OAUTH_REDIRECT_URI
@@ -86,6 +87,47 @@ class CookidooDevice:
     """A paired Thermomix appliance on the account."""
 
     type: ThermomixMachineType
+
+
+class CookidooCookState(StrEnum):
+    """State of an ongoing remote-monitored cook."""
+
+    RUNNING = "RUNNING"
+    PAUSED = "PAUSED"
+    DONE = "DONE"
+    ACKNOWLEDGED = "ACKNOWLEDGED"
+    STALE = "STALE"
+
+
+@dataclass
+class CookidooCookingActivity:
+    """Live cook state pushed by an appliance's remote monitoring.
+
+    Values the recipe does not provide are ``None`` (the app renders ``"---"``
+    for an unset current temperature, which is normalised to ``None`` here).
+    """
+
+    device_id: str
+    cooking_activity_id: str | None = None
+    state: CookidooCookState | None = None
+    recipe_id: str | None = None
+    recipe_type: str | None = None
+    recipe_name: str | None = None
+    step: str | None = None
+    remaining_seconds: int | None = None
+    is_time_estimated: bool = False
+    current_temperature: float | None = None
+    target_temperature: float | None = None
+    message_title: str | None = None
+    message_body: str | None = None
+    message_criticality: str | None = None
+    completed_at: datetime | None = None
+    stale_at: datetime | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """Whether a cook is currently running or paused."""
+        return self.state in (CookidooCookState.RUNNING, CookidooCookState.PAUSED)
 
 
 @dataclass

--- a/docs/raw-api-requests/get-monitored-devices.txt
+++ b/docs/raw-api-requests/get-monitored-devices.txt
@@ -1,0 +1,9 @@
+GET https://iot-api.production-eu.cookidoo.vorwerk-digital.com/devices HTTP/2.0
+authorization: Bearer eyJhbGciOiJS<redacted>
+accept: application/json
+
+
+HTTP/2.0 200
+content-type: application/json
+
+[{"deviceId":"22e920b2d6184cec6c854cd005d6aa8fb851d7e783478b50f361ac8d1ab97bfe"}]

--- a/docs/raw-api-requests/register-push-token.txt
+++ b/docs/raw-api-requests/register-push-token.txt
@@ -1,0 +1,13 @@
+POST https://iot-api.production-eu.cookidoo.vorwerk-digital.com/device-token HTTP/2.0
+authorization: Bearer eyJhbGciOiJS<redacted>
+rmi-api-version: 2026-06-01
+content-type: application/json
+accept: application/json
+
+{"token":"<fcm registration token>","bundleId":"com.vorwerk.cookidoo","platform":"AN","mobileAppId":"<per-install uuid>"}
+
+
+HTTP/2.0 200
+content-type: application/json
+
+{"message":"OK"}

--- a/docs/raw-api-requests/unregister-push-token.txt
+++ b/docs/raw-api-requests/unregister-push-token.txt
@@ -1,0 +1,13 @@
+DELETE https://iot-api.production-eu.cookidoo.vorwerk-digital.com/token HTTP/2.0
+authorization: Bearer eyJhbGciOiJS<redacted>
+rmi-api-version: 2026-06-01
+content-type: application/json
+accept: application/json
+
+{"tokens":["<fcm registration token>"]}
+
+
+HTTP/2.0 200
+content-type: application/json
+
+{"message":"OK"}

--- a/example.py
+++ b/example.py
@@ -74,6 +74,14 @@ async def main():
         # Paired Thermomix appliances on the account
         _devices = await cookidoo.get_devices()
 
+        # Appliances currently available for remote monitoring
+        _monitored = await cookidoo.get_monitored_device_ids()
+        # To receive live cook state, register a push token obtained from your own
+        # FCM client, then decode incoming data messages with
+        # cooking_activity_from_push(...):
+        #   await cookidoo.register_push_token(fcm_token, mobile_app_id)
+        #   activity = cooking_activity_from_push(message_data)
+
         # Some features are only available for premium accounts. To get a premium account, you need to subscribe to the Cookidoo service. When creating a new account, you get 1 month of premium for free which is enough to test the premium features :)
         ENABLE_PREMIUM = subscription and subscription.active
 

--- a/smoke_test/test_2_methods.py
+++ b/smoke_test/test_2_methods.py
@@ -40,6 +40,11 @@ class TestMethods:
         for device in devices:
             assert device.type in ThermomixMachineType
 
+    async def test_cookidoo_get_monitored_device_ids(self, cookidoo: Cookidoo) -> None:
+        """Test cookidoo get monitored device ids (empty unless an appliance is online)."""
+        ids = await cookidoo.get_monitored_device_ids()
+        assert isinstance(ids, list)
+
     @pytest.mark.parametrize(
         (
             "recipe_id",

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -110,6 +110,52 @@ COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE: Final = {
     "expires_in": 43200,
 }
 
+COOKIDOO_TEST_RESPONSE_MOBILE_HOME: Final = {
+    "_links": {
+        "tmde2:rmi-config": {
+            "href": "https://it.tmmobile.vorwerk-digital.com/rmi-config/.well-known/home"
+        }
+    }
+}
+
+COOKIDOO_TEST_RESPONSE_RMI_CONFIG: Final = {
+    "_links": {
+        "rmi:register-token": {
+            "href": "https://iot-api.production-eu.cookidoo.vorwerk-digital.com/device-token"
+        },
+        "rmi:unregister": {
+            "href": "https://iot-api.production-eu.cookidoo.vorwerk-digital.com/token"
+        },
+        "rmi:devices": {
+            "href": "https://iot-api.production-eu.cookidoo.vorwerk-digital.com/devices{?nonce}"
+        },
+    }
+}
+
+COOKIDOO_TEST_RESPONSE_MONITORED_DEVICES: Final = [
+    {"deviceId": "22e920b2d6184cec6c854cd005d6aa8fb851d7e783478b50f361ac8d1ab97bfe"}
+]
+
+# A real remote-monitoring push payload (Firebase data message; values are strings).
+COOKIDOO_TEST_PUSH_COOKING_ACTIVITY: Final = {
+    "deviceId": "22e920b2d6184cec6c854cd005d6aa8fb851d7e783478b50f361ac8d1ab97bfe",
+    "id": "986954277",
+    "cookingActivityId": "210c27aa-de31-4565-aad1-4f10e2c79deb",
+    "state": "running",
+    "recipeId": "r54743",
+    "recipeType": "vorwerk",
+    "leadingText": "Purè di patate",
+    "trailingText": "5/9",
+    "primaryInfo": "---",
+    "secondaryInfo": "95",
+    "separator": "/",
+    "isTimeEstimated": "false",
+    "iconId": "manual-values",
+    "completedDate": "2026-08-28T13:37:48Z",
+    "staleDate": "1787924895000",
+    "dismissalDate": "1787924388000",
+}
+
 COOKIDOO_TEST_RESPONSE_DEVICES: Final = ["TM7"]
 
 COOKIDOO_TEST_RESPONSE_DEVICES_MULTIPLE: Final = ["TM7", "TM6"]

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 import pytest
 from yarl import URL
 
+from cookidoo_api import cooking_activity_from_push
 from cookidoo_api.const import (
     CIAM_LOGIN_SRV_URL,
     OAUTH_CLIENT_ID,
@@ -33,6 +34,7 @@ from cookidoo_api.types import (
     CookidooAdditionalItem,
     CookidooAuthData,
     CookidooConfig,
+    CookidooCookState,
     CookidooIngredientItem,
     CookidooSearchResult,
     ThermomixMachineType,
@@ -41,6 +43,7 @@ from tests.conftest import TEST_CLIENT_ID, TEST_REDIRECT_URI
 from tests.responses import (
     COOKIDOO_TEST_LOGIN_PAGE_HTML,
     COOKIDOO_TEST_OIDC_DISCOVERY,
+    COOKIDOO_TEST_PUSH_COOKING_ACTIVITY,
     COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE,
     COOKIDOO_TEST_RESPONSE_ACTIVE_SUBSCRIPTION,
     COOKIDOO_TEST_RESPONSE_ADD_ADDITIONAL_ITEMS,
@@ -69,9 +72,12 @@ from tests.responses import (
     COOKIDOO_TEST_RESPONSE_GET_SHOPPING_LIST_RECIPES,
     COOKIDOO_TEST_RESPONSE_INACTIVE_SUBSCRIPTION,
     COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES,
+    COOKIDOO_TEST_RESPONSE_MOBILE_HOME,
+    COOKIDOO_TEST_RESPONSE_MONITORED_DEVICES,
     COOKIDOO_TEST_RESPONSE_REMOVE_CUSTOM_RECIPE_FROM_CALENDAR,
     COOKIDOO_TEST_RESPONSE_REMOVE_RECIPE_FROM_CALENDAR,
     COOKIDOO_TEST_RESPONSE_REMOVE_RECIPE_FROM_CUSTOM_COLLECTION,
+    COOKIDOO_TEST_RESPONSE_RMI_CONFIG,
     COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
     COOKIDOO_TEST_RESPONSE_USER_INFO,
     COOKIDOO_TEST_TOKEN_RESPONSE,
@@ -4000,3 +4006,91 @@ class TestRemoveCustomRecipeFromCalendar:
                 datetime.fromisoformat("2025-08-11").date(),
                 "01K2CTJ9Y1BABRG5MXK44CFZS4",
             )
+
+
+class TestRemoteMonitoring:
+    """Tests for remote-monitoring (device management) methods."""
+
+    MOBILE_HOME_URL = "https://cookidoo.ch/.well-known/mobile-home"
+    RMI_CONFIG_URL = (
+        "https://it.tmmobile.vorwerk-digital.com/rmi-config/.well-known/home"
+    )
+    DEVICES_URL = "https://iot-api.production-eu.cookidoo.vorwerk-digital.com/devices"
+    REGISTER_URL = (
+        "https://iot-api.production-eu.cookidoo.vorwerk-digital.com/device-token"
+    )
+    UNREGISTER_URL = "https://iot-api.production-eu.cookidoo.vorwerk-digital.com/token"
+
+    def _mock_rmi_resolution(self, mocked: aioresponses) -> None:
+        mocked.get(self.MOBILE_HOME_URL, payload=COOKIDOO_TEST_RESPONSE_MOBILE_HOME)
+        mocked.get(self.RMI_CONFIG_URL, payload=COOKIDOO_TEST_RESPONSE_RMI_CONFIG)
+
+    async def test_get_monitored_device_ids(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test listing monitorable device ids."""
+        self._mock_rmi_resolution(mocked)
+        mocked.get(self.DEVICES_URL, payload=COOKIDOO_TEST_RESPONSE_MONITORED_DEVICES)
+
+        ids = await cookidoo.get_monitored_device_ids()
+        assert ids == [
+            "22e920b2d6184cec6c854cd005d6aa8fb851d7e783478b50f361ac8d1ab97bfe"
+        ]
+
+    async def test_get_monitored_device_ids_empty(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test listing when no device is currently monitorable."""
+        self._mock_rmi_resolution(mocked)
+        mocked.get(self.DEVICES_URL, payload=[])
+
+        assert await cookidoo.get_monitored_device_ids() == []
+
+    async def test_register_push_token(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test registering a push token."""
+        self._mock_rmi_resolution(mocked)
+        mocked.post(self.REGISTER_URL, payload={"message": "OK"})
+
+        await cookidoo.register_push_token("fcm-token", "app-install-id")
+
+    async def test_unregister_push_token(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Test unregistering a push token."""
+        self._mock_rmi_resolution(mocked)
+        mocked.delete(self.UNREGISTER_URL, payload={"message": "OK"})
+
+        await cookidoo.unregister_push_token("fcm-token")
+
+    async def test_rmi_config_link_missing(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A home doc without the rmi-config link raises."""
+        mocked.get(self.MOBILE_HOME_URL, payload={"_links": {}})
+
+        with pytest.raises(CookidooParseException, match="rmi-config link missing"):
+            await cookidoo.get_monitored_device_ids()
+
+    def test_cooking_activity_from_push(self) -> None:
+        """Test decoding a remote-monitoring push payload."""
+        activity = cooking_activity_from_push(COOKIDOO_TEST_PUSH_COOKING_ACTIVITY)
+        assert activity.state == CookidooCookState.RUNNING
+        assert activity.is_active
+        assert activity.recipe_name == "Purè di patate"
+        assert activity.step == "5/9"
+        assert activity.target_temperature == 95.0
+        assert activity.current_temperature is None  # "---" -> None
+        assert activity.is_time_estimated is False  # "false" -> False
+        assert activity.recipe_type == "VORWERK"
+        assert activity.completed_at is not None
+        assert activity.stale_at is not None and activity.stale_at.year == 2026
+
+    def test_cooking_activity_from_push_done_is_inactive(self) -> None:
+        """A done cook is not active."""
+        activity = cooking_activity_from_push(
+            {**COOKIDOO_TEST_PUSH_COOKING_ACTIVITY, "state": "done"}
+        )
+        assert activity.state == CookidooCookState.DONE
+        assert not activity.is_active

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -4073,6 +4073,155 @@ class TestRemoteMonitoring:
         with pytest.raises(CookidooParseException, match="rmi-config link missing"):
             await cookidoo.get_monitored_device_ids()
 
+    async def test_rmi_links_are_cached(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """The resolution walk runs once and is reused afterwards."""
+        self._mock_rmi_resolution(mocked)
+        mocked.get(self.DEVICES_URL, payload=[])
+        mocked.get(self.DEVICES_URL, payload=[])
+
+        await cookidoo.get_monitored_device_ids()
+        await cookidoo.get_monitored_device_ids()
+
+        # Only the first call walked mobile-home -> rmi-config.
+        assert len(mocked.requests[("get", URL(self.MOBILE_HOME_URL))]) == 1
+        assert len(mocked.requests[("get", URL(self.RMI_CONFIG_URL))]) == 1
+
+    async def test_mobile_home_without_links(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A home doc whose ``_links`` is not an object raises."""
+        mocked.get(self.MOBILE_HOME_URL, payload={"_links": "not-an-object"})
+
+        with pytest.raises(CookidooParseException, match="rmi-config link missing"):
+            await cookidoo.get_monitored_device_ids()
+
+    async def test_rmi_config_without_links(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """An rmi-config document without a ``_links`` object raises."""
+        mocked.get(self.MOBILE_HOME_URL, payload=COOKIDOO_TEST_RESPONSE_MOBILE_HOME)
+        mocked.get(self.RMI_CONFIG_URL, payload={"_links": "not-an-object"})
+
+        with pytest.raises(CookidooParseException, match="during parsing"):
+            await cookidoo.get_monitored_device_ids()
+
+    async def test_rmi_links_accept_both_hal_shapes(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A rel maps either to a bare href string or to a ``{"href": ...}``."""
+        mocked.get(
+            self.MOBILE_HOME_URL,
+            payload={"_links": {"tmde2:rmi-config": self.RMI_CONFIG_URL}},
+        )
+        mocked.get(
+            self.RMI_CONFIG_URL,
+            payload={
+                "_links": {
+                    "rmi:devices": self.DEVICES_URL,
+                    "rmi:unregister": {"href": self.UNREGISTER_URL},
+                    "rmi:ignored": {"no-href": True},
+                }
+            },
+        )
+        mocked.get(self.DEVICES_URL, payload=[])
+
+        assert await cookidoo.get_monitored_device_ids() == []
+
+    @pytest.mark.parametrize(
+        ("rel", "call", "args"),
+        [
+            ("rmi:devices", "get_monitored_device_ids", ()),
+            ("rmi:register-token", "register_push_token", ("fcm-token", "install-id")),
+            ("rmi:unregister", "unregister_push_token", ("fcm-token",)),
+        ],
+    )
+    async def test_rmi_endpoint_link_missing(
+        self,
+        mocked: aioresponses,
+        cookidoo: Cookidoo,
+        rel: str,
+        call: str,
+        args: tuple[str, ...],
+    ) -> None:
+        """Each endpoint reports its own missing link rather than failing late."""
+        links = {
+            k: v
+            for k, v in COOKIDOO_TEST_RESPONSE_RMI_CONFIG["_links"].items()
+            if k != rel
+        }
+        mocked.get(self.MOBILE_HOME_URL, payload=COOKIDOO_TEST_RESPONSE_MOBILE_HOME)
+        mocked.get(self.RMI_CONFIG_URL, payload={"_links": links})
+
+        with pytest.raises(CookidooParseException, match=f"{rel} link missing"):
+            await getattr(cookidoo, call)(*args)
+
+    @pytest.mark.parametrize(
+        ("field", "value", "attr", "expected"),
+        [
+            # _push_timestamp: unparseable and empty strings degrade to None
+            ("completedDate", "not-a-date", "completed_at", None),
+            ("completedDate", "", "completed_at", None),
+            ("completedDate", None, "completed_at", None),
+            ("completedDate", ["unexpected", "shape"], "completed_at", None),
+            # _push_number: sentinels, comma decimals and native numbers
+            ("secondaryInfo", "---", "target_temperature", None),
+            ("secondaryInfo", "", "target_temperature", None),
+            ("secondaryInfo", "not-a-number", "target_temperature", None),
+            ("secondaryInfo", "37,5", "target_temperature", 37.5),
+            ("secondaryInfo", 95, "target_temperature", 95.0),
+            ("secondaryInfo", None, "target_temperature", None),
+            # _push_bool: real bools pass through, strings are coerced
+            ("isTimeEstimated", True, "is_time_estimated", True),
+            ("isTimeEstimated", "yes", "is_time_estimated", True),
+            ("isTimeEstimated", "FALSE", "is_time_estimated", False),
+            ("isTimeEstimated", 1, "is_time_estimated", True),
+        ],
+    )
+    def test_cooking_activity_from_push_field_parsing(
+        self, field: str, value: object, attr: str, expected: object
+    ) -> None:
+        """Malformed or alternately-typed push fields degrade instead of raising."""
+        payload = {**COOKIDOO_TEST_PUSH_COOKING_ACTIVITY, field: value}
+
+        assert getattr(cooking_activity_from_push(payload), attr) == expected
+
+    @pytest.mark.parametrize("remaining", ["600", 600])
+    def test_cooking_activity_from_push_remaining_duration(
+        self, remaining: object
+    ) -> None:
+        """``remainingDuration`` arrives as a string or an int; both are used."""
+        payload = {
+            **COOKIDOO_TEST_PUSH_COOKING_ACTIVITY,
+            "remainingDuration": remaining,
+        }
+
+        assert cooking_activity_from_push(payload).remaining_seconds == 600
+
+    def test_cooking_activity_from_push_remaining_duration_unparseable(self) -> None:
+        """An unparseable duration falls back to deriving it from the finish time."""
+        payload = {
+            **COOKIDOO_TEST_PUSH_COOKING_ACTIVITY,
+            "remainingDuration": "not-a-number",
+        }
+
+        remaining = cooking_activity_from_push(payload).remaining_seconds
+        assert remaining is None or isinstance(remaining, int)
+
+    def test_cooking_activity_from_push_epoch_seconds(self) -> None:
+        """Epoch timestamps arrive in millis or seconds; both decode."""
+        millis = cooking_activity_from_push(
+            {**COOKIDOO_TEST_PUSH_COOKING_ACTIVITY, "completedDate": "1787924895000"}
+        )
+        seconds = cooking_activity_from_push(
+            {**COOKIDOO_TEST_PUSH_COOKING_ACTIVITY, "completedDate": 1787924895}
+        )
+
+        assert millis.completed_at is not None
+        assert seconds.completed_at is not None
+        assert millis.completed_at == seconds.completed_at
+
     def test_cooking_activity_from_push(self) -> None:
         """Test decoding a remote-monitoring push payload."""
         activity = cooking_activity_from_push(COOKIDOO_TEST_PUSH_COOKING_ACTIVITY)


### PR DESCRIPTION
## Summary

Adds the **remote-monitoring / device-management** surface, built on the OAuth2 bearer auth. These endpoints live on the IoT backend (`iot-api.production-eu.cookidoo.vorwerk-digital.com`) and returned **401 under the old cookie session** — they only work with the bearer token.

- `get_monitored_device_ids()` — appliances currently available for monitoring (`rmi:devices`); distinct from `get_devices()` (all paired appliances)
- `register_push_token()` / `unregister_push_token()` — manage the FCM push subscription that delivers live cook state
- `cooking_activity_from_push()` + `CookidooCookingActivity` / `CookidooCookState` — decode the out-of-band Firebase data-message payload into a typed model (lowercase wire enums, `"---"` → `None`, string booleans, derived remaining time, all handled)

Endpoints are discovered via the mobile home document → `rmi-config` sub-document and cached. Receiving the FCM messages themselves stays the caller's responsibility (e.g. the Home Assistant integration); this library provides the REST surface and the payload decoder.

> Rebased onto `master` now that #257 (the OAuth2 switch) is merged — this branch is down to its own two commits and applies cleanly.

## Verification

- `pytest`: 330 passed, coverage 100%
- `ruff check` / `ruff format --check`: clean
- `mypy`: clean
- Verified live against a real account: `get_monitored_device_ids()`, `register_push_token()` + `unregister_push_token()` round-trip (200 `{"message":"OK"}`), and `cooking_activity_from_push()` decoding a real payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPafaf8wbvdUnDP25iiuiy
