### PR TITLE
Raise a clear ValueError instead of StopIteration for missing recipe times

### DIFF
--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -328,6 +328,31 @@ def cookidoo_recipe_details_from_json(
         thumbnail, image = _extract_images_from_descriptive_assets(descriptive_assets)
     url = _construct_recipe_url(localization, recipe["id"])
 
+    active_time = next(
+        (
+            time_["quantity"]["value"]
+            for time_ in recipe["times"]
+            if time_["type"] == "activeTime" and time_["quantity"]["value"]
+        ),
+        None,
+    )
+    if active_time is None:
+        raise ValueError(
+            "Recipe details response is missing a non-null 'activeTime' entry in 'times'."
+        )
+    total_time = next(
+        (
+            time_["quantity"]["value"]
+            for time_ in recipe["times"]
+            if time_["type"] == "totalTime" and time_["quantity"]["value"]
+        ),
+        None,
+    )
+    if total_time is None:
+        raise ValueError(
+            "Recipe details response is missing a non-null 'totalTime' entry in 'times'."
+        )
+
     return CookidooShoppingRecipeDetails(
         id=recipe["id"],
         name=recipe["title"],
@@ -357,16 +382,8 @@ def cookidoo_recipe_details_from_json(
         ],
         utensils=[utensil["utensilNotation"] for utensil in recipe["recipeUtensils"]],
         serving_size=recipe["servingSize"]["quantity"]["value"] or 0,
-        active_time=next(
-            time_["quantity"]["value"]
-            for time_ in recipe["times"]
-            if time_["type"] == "activeTime" and time_["quantity"]["value"]
-        ),
-        total_time=next(
-            time_["quantity"]["value"]
-            for time_ in recipe["times"]
-            if time_["type"] == "totalTime" and time_["quantity"]["value"]
-        ),
+        active_time=active_time,
+        total_time=total_time,
         nutrition_groups=[
             CookidooNutritionGroup(
                 name=ng["name"],

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -936,6 +936,26 @@ class TestGetRecipeDetails:
         with pytest.raises(exception):
             await cookidoo.get_recipe_details("r907015")
 
+    async def test_missing_times_raises_parse_exception(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A recipe missing a non-null activeTime/totalTime raises CookidooParseException.
+
+        Previously this raised a bare StopIteration, which is not a documented
+        exception of this method and is not even guaranteed to propagate as
+        StopIteration out of an async function (PEP 479).
+        """
+        payload = COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS.copy()
+        payload["times"] = []
+        mocked.get(
+            "https://cookidoo.ch/recipes/recipe/de-CH/r907015",
+            payload=payload,
+            status=HTTPStatus.OK,
+        )
+
+        with pytest.raises(CookidooParseException):
+            await cookidoo.get_recipe_details("r907015")
+
 
 class TestSearchRecipes:
     """Tests for search_recipes method."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,7 +59,17 @@ class TestLocalization:
         JSON = cast(RecipeDetailsJSON, COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS.copy())
         JSON["times"] = []
 
-        with pytest.raises(StopIteration):
+        with pytest.raises(ValueError, match="activeTime"):
+            cookidoo_recipe_details_from_json(JSON)
+
+    async def test_cookidoo_recipe_details_from_json_missing_total_time(self) -> None:
+        """Test get recipe details from json with only activeTime present."""
+        JSON = cast(RecipeDetailsJSON, COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS.copy())
+        JSON["times"] = [
+            {"type": "activeTime", "comment": "", "quantity": {"value": 2700}}
+        ]
+
+        with pytest.raises(ValueError, match="totalTime"):
             cookidoo_recipe_details_from_json(JSON)
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -66,7 +66,11 @@ class TestLocalization:
         """Test get recipe details from json with only activeTime present."""
         JSON = cast(RecipeDetailsJSON, COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS.copy())
         JSON["times"] = [
-            {"type": "activeTime", "comment": "", "quantity": {"value": 2700}}
+            {
+                "type": "activeTime",
+                "comment": "",
+                "quantity": {"value": 2700, "from": None, "to": None},
+            }
         ]
 
         with pytest.raises(ValueError, match="totalTime"):


### PR DESCRIPTION
## What

`cookidoo_recipe_details_from_json` builds `active_time`/`total_time` with
`next(...)` and no default. A recipe details response whose `times` array
lacks a non-null `activeTime` or `totalTime` entry raises a bare
`StopIteration`.

That's not one of `get_recipe_details`'s documented exceptions, it isn't
caught by `Cookidoo._parse_result`'s `(KeyError, TypeError, ValueError)`
tuple, and per [PEP 479](https://peps.python.org/pep-0479/) it isn't even
guaranteed to propagate as `StopIteration` out of an async call — it can
surface as a confusing `RuntimeError` instead, depending on where it's
awaited.

## Fix

Extract both `next(...)` calls to their `default=None` form and raise a
descriptive `ValueError` when either is missing. `_parse_result`'s existing
catch turns that into the documented `CookidooParseException`, consistent
with every other recipe-details parse failure — no new exception type, no
change to `_parse_result` itself. Field values are unaffected; only the
missing-data failure mode changes.

## Tests

- Updated `test_cookidoo_recipe_details_from_json_exception`, which
  previously asserted the `StopIteration` as the *expected* outcome, to
  assert the new `ValueError` instead.
- Added a sibling case for a missing `totalTime` alone.
- Added an integration-level test on `Cookidoo.get_recipe_details` confirming
  `CookidooParseException` propagates end-to-end.

`pytest`, `ruff`, and `mypy` all pass locally.

## Context

Found while building a read-only meal-planning bridge on top of this
library — a probe across 19 real recipes found 0 that would trigger this, so
I can't offer a hit-rate; it's a robustness fix for a real gap in the parser,
not a frequently-observed crash in this sample.