### PR TITLE
Add step_groups to recipe details

### DIFF
--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -47,6 +47,8 @@ from cookidoo_api.types import (
     CookidooNutritionGroup,
     CookidooRecipeCollection,
     CookidooRecipeNutrition,
+    CookidooRecipeStep,
+    CookidooRecipeStepGroup,
     CookidooSearchRecipeHit,
     CookidooSearchResult,
     CookidooShoppingRecipe,
@@ -387,6 +389,19 @@ def cookidoo_recipe_details_from_json(
                 ],
             )
             for ng in recipe.get("nutritionGroups", [])
+        ],
+        step_groups=[
+            CookidooRecipeStepGroup(
+                title=sg["title"],
+                recipe_steps=[
+                    CookidooRecipeStep(
+                        title=step["title"],
+                        formatted_text=step["formattedText"],
+                    )
+                    for step in sg["recipeSteps"]
+                ],
+            )
+            for sg in recipe.get("recipeStepGroups", [])
         ],
         thumbnail=thumbnail,
         image=image,

--- a/cookidoo_api/types.py
+++ b/cookidoo_api/types.py
@@ -329,6 +329,40 @@ class CookidooNutritionGroup:
 
 
 @dataclass
+class CookidooRecipeStep:
+    """Recipe step type.
+
+    Attributes
+    ----------
+    title
+        The title of the step (may be empty)
+    formatted_text
+        The instruction text for the step, as HTML markup
+
+    """
+
+    title: str
+    formatted_text: str
+
+
+@dataclass
+class CookidooRecipeStepGroup:
+    """Recipe step group type.
+
+    Attributes
+    ----------
+    title
+        The title of the step group (may be empty)
+    recipe_steps
+        List of recipe steps in this group
+
+    """
+
+    title: str
+    recipe_steps: list[CookidooRecipeStep]
+
+
+@dataclass
 class CookidooShoppingRecipeDetails(CookidooShoppingRecipe):
     """Cookidoo recipe details type.
 
@@ -352,6 +386,10 @@ class CookidooShoppingRecipeDetails(CookidooShoppingRecipe):
         The time needed until the recipe is ready [in seconds]
     nutrition_groups
         The nutrition groups of the recipe (from API, may be empty)
+    step_groups
+        The grouped cooking instructions for the recipe (from API, may be
+        empty). Instruction text is returned as HTML markup, as sent by the
+        API.
 
     """
 
@@ -364,6 +402,7 @@ class CookidooShoppingRecipeDetails(CookidooShoppingRecipe):
     active_time: int
     total_time: int
     nutrition_groups: list[CookidooNutritionGroup]
+    step_groups: list[CookidooRecipeStepGroup]
 
 
 @dataclass

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -884,8 +884,10 @@ class TestGetRecipeDetails:
         assert data.step_groups[0].title == ""
         assert len(data.step_groups[0].recipe_steps) == 4
         assert data.step_groups[0].recipe_steps[0].title == "1"
-        assert data.step_groups[0].recipe_steps[0].formatted_text.startswith(
-            "<NOBR>200 g Kokosraspeln</NOBR>"
+        assert (
+            data.step_groups[0]
+            .recipe_steps[0]
+            .formatted_text.startswith("<NOBR>200 g Kokosraspeln</NOBR>")
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -880,6 +880,13 @@ class TestGetRecipeDetails:
         assert isinstance(data.active_time, int)
         assert isinstance(data.total_time, int)
         assert isinstance(data.serving_size, int)
+        assert len(data.step_groups) == 1
+        assert data.step_groups[0].title == ""
+        assert len(data.step_groups[0].recipe_steps) == 4
+        assert data.step_groups[0].recipe_steps[0].title == "1"
+        assert data.step_groups[0].recipe_steps[0].formatted_text.startswith(
+            "<NOBR>200 g Kokosraspeln</NOBR>"
+        )
 
     @pytest.mark.parametrize(
         "exception",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -219,6 +219,36 @@ class TestRecipeImagesAndUrls:
         assert result.image is None
         assert result.url == "https://cookidoo.ch/recipes/recipe/de-CH/r907015"
 
+    def test_cookidoo_recipe_details_from_json_step_groups(self) -> None:
+        """Test cookidoo_recipe_details_from_json converts step groups."""
+        recipe_json = cast(
+            RecipeDetailsJSON,
+            COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS.copy(),
+        )
+
+        result = cookidoo_recipe_details_from_json(recipe_json)
+
+        assert len(result.step_groups) == 1
+        group = result.step_groups[0]
+        assert group.title == ""
+        assert len(group.recipe_steps) == 4
+        assert group.recipe_steps[0].title == "1"
+        assert group.recipe_steps[0].formatted_text.startswith(
+            "<NOBR>200 g Kokosraspeln</NOBR>"
+        )
+
+    def test_cookidoo_recipe_details_from_json_without_step_groups(self) -> None:
+        """Test cookidoo_recipe_details_from_json handles a missing recipeStepGroups key."""
+        recipe_json = cast(
+            RecipeDetailsJSON,
+            COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS.copy(),
+        )
+        del recipe_json["recipeStepGroups"]
+
+        result = cookidoo_recipe_details_from_json(recipe_json)
+
+        assert result.step_groups == []
+
     def test_cookidoo_custom_recipe_from_json_with_image(self) -> None:
         """Test cookidoo_custom_recipe_from_json extracts image correctly."""
         recipe_json = cast(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -239,13 +239,10 @@ class TestRecipeImagesAndUrls:
 
     def test_cookidoo_recipe_details_from_json_without_step_groups(self) -> None:
         """Test cookidoo_recipe_details_from_json handles a missing recipeStepGroups key."""
-        recipe_json = cast(
-            RecipeDetailsJSON,
-            COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS.copy(),
-        )
+        recipe_json = dict(COOKIDOO_TEST_RESPONSE_GET_RECIPE_DETAILS)
         del recipe_json["recipeStepGroups"]
 
-        result = cookidoo_recipe_details_from_json(recipe_json)
+        result = cookidoo_recipe_details_from_json(cast(RecipeDetailsJSON, recipe_json))
 
         assert result.step_groups == []
 


### PR DESCRIPTION
## What

`RecipeDetailsJSON` already declares `recipeStepGroups`, and the raw API
response carries it, but `cookidoo_recipe_details_from_json` never reads it.
`CookidooShoppingRecipeDetails` carries ingredients, timing, and nutrition,
but no cooking instructions at all — every consumer of `get_recipe_details`
currently has no way to know how to actually make the recipe from this
library alone.

## What this adds

- `CookidooRecipeStep` (`title`, `formatted_text`)
- `CookidooRecipeStepGroup` (`title`, `recipe_steps`)
- `CookidooShoppingRecipeDetails.step_groups: list[CookidooRecipeStepGroup]`,
  converted from `recipe.get("recipeStepGroups", [])` the same way
  `nutrition_groups` already is (default to `[]` when absent, same
  group→items nesting).

`formatted_text` is left as the HTML markup the API sends (e.g.
`<NOBR>200 g ...</NOBR>`), matching how other text fields like `notes` are
already exposed unprocessed elsewhere in this library. Stripping markup felt
like a presentation decision that belongs to the caller, not this library,
but happy to hear if you'd rather it be handled here.

## Open to adjusting

This is new public API surface rather than a pure bugfix, so the naming
(`step_groups`/`CookidooRecipeStep(Group)`) and the raw-HTML choice above are
both just what seemed most consistent with the existing `nutrition_groups`
pattern — genuinely happy to rename or restructure if you'd prefer a
different shape.

## Tests

- Unit tests on `cookidoo_recipe_details_from_json` for the populated and
  missing-key cases.
- Extended the existing `get_recipe_details` integration test to assert on
  `step_groups`.

`pytest`, `ruff`, and `mypy` all pass locally.

## Context

Found while building a read-only meal-planning bridge on top of this
library, where the missing steps meant working around it with a private,
undocumented raw HTTP call just to get cooking instructions.