### PR TITLE
fix: three issues in the OAuth2 fallback branch

### DIFF
--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -62,7 +62,14 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             pip install -r requirements_test.txt
+      # `pull_request_target` checks out the *base* branch, so the two setup
+      # steps below run the base branch's code with the password. That branch
+      # can only prepare the sessions it knows about: a base without the OAuth2
+      # login yields no .token, and one without test_1_setup_cookies.py yields
+      # no .cookies. Each batch is therefore skipped when its session file is
+      # missing, and the job fails if neither could be prepared.
       - name: Prepare token with pytest
+        continue-on-error: true
         run: pytest smoke_test/test_1_setup_token.py -v -x
         env:
           COUNTRY: ${{ matrix.country }}
@@ -75,9 +82,8 @@ jobs:
           CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
           REDIRECT_URI: ${{ vars.OAUTH_REDIRECT_URI }}
-      - name: Preserve token
-        run: cp .token /tmp/.token
       - name: Prepare cookies with pytest
+        continue-on-error: true
         run: pytest smoke_test/test_1_setup_cookies.py -v -x
         env:
           COUNTRY: ${{ matrix.country }}
@@ -87,8 +93,28 @@ jobs:
           EMAIL_MA: ${{ vars.EMAIL_MA }}
           EMAIL_IE: ${{ vars.EMAIL_IE }}
           PASSWORD: ${{ secrets.PASSWORD }}
-      - name: Preserve cookies
-        run: cp .cookies /tmp/.cookies
+      - name: Preserve prepared sessions
+        id: sessions
+        run: |
+          if [[ -f .token ]]; then
+            cp .token /tmp/.token
+            echo "token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Base branch prepared no .token, skipping the OAuth2 batch"
+            echo "token=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ -f .cookies ]]; then
+            cp .cookies /tmp/.cookies
+            echo "cookies=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Base branch prepared no .cookies, skipping the cookie-session batch"
+            echo "cookies=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Check a session could be prepared
+        if: steps.sessions.outputs.token == 'false' && steps.sessions.outputs.cookies == 'false'
+        run: |
+          echo "Neither login method could prepare a session on the base branch."
+          exit 1
       # !!!!!!!!!!!!!!!!!!!!
       # From here on, we run new code which does not have access to the password, only the token/cookies
       # !!!!!!!!!!!!!!!!!!!!
@@ -98,9 +124,11 @@ jobs:
           ref: "${{ github.event.pull_request.merge_commit_sha }}"
           clean: false
       - name: Restore token
+        if: steps.sessions.outputs.token == 'true'
         run: cp /tmp/.token .token
       # OAuth2 login is the primary method, run its methods batch first.
       - name: Test OAuth2 login with pytest
+        if: steps.sessions.outputs.token == 'true'
         run: pytest smoke_test/test_2_methods.py -v -x
         env:
           COUNTRY: ${{ matrix.country }}
@@ -114,8 +142,10 @@ jobs:
       # completes (sequentially, in the same job) so the two login methods
       # don't clash by running concurrently against the same test account.
       - name: Restore cookies
+        if: steps.sessions.outputs.cookies == 'true'
         run: cp /tmp/.cookies .cookies
       - name: Test cookie-session login with pytest
+        if: steps.sessions.outputs.cookies == 'true'
         run: pytest smoke_test/test_2_methods.py -v -x
         env:
           COUNTRY: ${{ matrix.country }}

--- a/cookidoo_api/const.py
+++ b/cookidoo_api/const.py
@@ -35,6 +35,9 @@ OAUTH_SCOPE: Final = "openid profile email offline offline_access"
 # Refresh a little before the (12h) access token actually expires.
 TOKEN_EXPIRY_MARGIN_S: Final = 300
 
+# Cookies the legacy cookie-session login must end up with to be authenticated.
+REQUIRED_AUTH_COOKIES: Final = frozenset({"_oauth2_proxy", "v-authenticated"})
+
 LOGIN_PATH: Final = "profile/{language}/login"
 LOGIN_REDIRECT: Final = "%2Ffoundation%2F{language}%2Ffor-you"
 RECIPE_PATH: Final = "recipes/recipe/{language}/{id}"

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -15,7 +15,7 @@ import re
 import secrets
 import time
 import traceback
-from typing import TypeVar, cast
+from typing import Literal, TypeVar, cast
 from urllib.parse import parse_qs, urljoin, urlparse
 
 from aiohttp import ClientError, ClientSession
@@ -59,6 +59,7 @@ from cookidoo_api.const import (
     REMOVE_MANAGED_COLLECTION_PATH,
     REMOVE_RECIPE_FROM_CALENDER_PATH,
     REMOVE_RECIPE_FROM_CUSTOM_COLLECTION_PATH,
+    REQUIRED_AUTH_COOKIES,
     SHOPPING_LIST_RECIPES_PATH,
     SUBSCRIPTIONS_PATH,
     TOKEN_EXPIRY_MARGIN_S,
@@ -128,6 +129,7 @@ class Cookidoo:
     _cfg: CookidooConfig
     _api_headers: dict[str, str]
     _logged_in: bool
+    _auth_mode: Literal["oauth", "cookie"] | None
     _refresh_token: str | None
     _expires_at: float
     _oidc: dict[str, str] | None
@@ -153,6 +155,7 @@ class Cookidoo:
         self._cfg = cfg
         self._api_headers = DEFAULT_API_HEADERS.copy()
         self._logged_in = False
+        self._auth_mode = None
         self._refresh_token = None
         self._expires_at = 0.0
         self._oidc = None
@@ -345,8 +348,16 @@ class Cookidoo:
 
     @property
     def auth_data(self) -> CookidooAuthData | None:
-        """The current OAuth2 tokens, for persistence. ``None`` until logged in."""
-        if not self._logged_in or self._refresh_token is None:
+        """The current OAuth2 tokens, for persistence.
+
+        ``None`` until logged in, and always ``None`` for the cookie-session
+        login, which has no tokens to persist (use :meth:`save_cookies` there).
+        """
+        if (
+            not self._logged_in
+            or self._auth_mode != "oauth"
+            or self._refresh_token is None
+        ):
             return None
         return CookidooAuthData(
             access_token=self._api_headers["Authorization"].removeprefix("Bearer "),
@@ -363,6 +374,7 @@ class Cookidoo:
         self._api_headers["Authorization"] = f"Bearer {auth_data.access_token}"
         self._refresh_token = auth_data.refresh_token
         self._expires_at = auth_data.expires_at
+        self._auth_mode = "oauth"
         self._logged_in = True
 
     async def login(self) -> None:
@@ -473,6 +485,7 @@ class Cookidoo:
 
             # Step 5: exchange the code for tokens
             await self._exchange_code(oidc["token_endpoint"], code, verifier)
+            self._auth_mode = "oauth"
             self._logged_in = True
 
         except (CookidooAuthException, CookidooParseException):
@@ -510,6 +523,12 @@ class Cookidoo:
             If the login fails due to invalid credentials.
 
         """
+        # Drop any OAuth2 token state left over from a previous login or from
+        # apply_auth_data()/load_token(), so the cookie session is not shadowed
+        # by a stale bearer header and _ensure_token() does not try to refresh
+        # a token this flow can neither use nor renew.
+        self._discard_token_state()
+
         language = self._cfg.localization.language
         login_path = LOGIN_PATH.format(language=language)
         redirect = LOGIN_REDIRECT.format(language=language)
@@ -549,6 +568,7 @@ class Cookidoo:
 
             # Step 4: Verify authentication cookies were set
             self._verify_auth_cookies()
+            self._auth_mode = "cookie"
             self._logged_in = True
 
         except CookidooAuthException:
@@ -566,11 +586,20 @@ class Cookidoo:
                 "Authentication failed due to request exception."
             ) from e
 
+    def _discard_token_state(self) -> None:
+        """Drop all OAuth2 token state, leaving the session cookies untouched."""
+        self._api_headers.pop("Authorization", None)
+        self._refresh_token = None
+        self._expires_at = 0.0
+
+    def _has_auth_cookies(self) -> bool:
+        """Whether the session cookie jar holds the required auth cookies."""
+        cookie_names = {c.key for c in self._session.cookie_jar}
+        return REQUIRED_AUTH_COOKIES.issubset(cookie_names)
+
     def _verify_auth_cookies(self) -> None:
         """Verify that required authentication cookies are present."""
-        cookie_names = {c.key for c in self._session.cookie_jar}
-        required_cookies = {"_oauth2_proxy", "v-authenticated"}
-        if not required_cookies.issubset(cookie_names):
+        if not self._has_auth_cookies():
             raise CookidooAuthException(
                 "Login failed: authentication cookies were not set. "
                 "Please check your email and password."
@@ -701,9 +730,9 @@ class Cookidoo:
             )
 
         # Check if required auth cookies are present
-        cookie_names = {c.key for c in self._session.cookie_jar}
-        required_cookies = {"_oauth2_proxy", "v-authenticated"}
-        if required_cookies.issubset(cookie_names):
+        if self._has_auth_cookies():
+            self._discard_token_state()
+            self._auth_mode = "cookie"
             self._logged_in = True
 
     # -- internal auth helpers --------------------------------------------
@@ -804,10 +833,10 @@ class Cookidoo:
     async def _ensure_token(self) -> None:
         """Refresh the access token if it is missing or about to expire.
 
-        A no-op for the cookie-session login (no refresh token is ever set),
-        since that flow authenticates via the session's cookie jar instead.
+        A no-op for the cookie-session login, since that flow authenticates via
+        the session's cookie jar and has no token to refresh.
         """
-        if not self._logged_in or self._refresh_token is None:
+        if not self._logged_in or self._auth_mode != "oauth":
             return
         if time.time() >= self._expires_at - TOKEN_EXPIRY_MARGIN_S:
             await self.refresh()

--- a/example.py
+++ b/example.py
@@ -64,16 +64,26 @@ async def main():
             ),
         )
 
-        # Try to reuse a saved token, otherwise login fresh. If the OAuth2
-        # client credentials above are not set, login() falls back to the
-        # cookie-session flow instead; use save_cookies()/load_cookies() to
-        # persist that session in the same way.
+        # Try to reuse a saved session, otherwise login fresh. Which file holds
+        # it depends on the login method: the OAuth2 flow persists tokens with
+        # save_token()/load_token(), the cookie-session fallback (used when the
+        # OAuth2 client credentials above are not set) persists the session with
+        # save_cookies()/load_cookies().
         token_file = ".token"
+        cookie_file = ".cookies"
         try:
             cookidoo.load_token(token_file)
         except Exception:
-            await cookidoo.login()
-            cookidoo.save_token(token_file)
+            try:
+                cookidoo.load_cookies(cookie_file)
+            except Exception:
+                await cookidoo.login()
+                # The OAuth2 flow yields tokens, the cookie-session fallback
+                # does not (auth_data stays None), so persist accordingly.
+                if cookidoo.auth_data is not None:
+                    cookidoo.save_token(token_file)
+                else:
+                    cookidoo.save_cookies(cookie_file)
 
         # Info
         await cookidoo.get_user_info()

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -436,6 +436,52 @@ class TestLoginCookie:
         await cookidoo_cookie.login()
 
         assert cookidoo_cookie._logged_in
+        assert cookidoo_cookie._auth_mode == "cookie"
+        # Nothing to persist as a token, the session lives in the cookie jar.
+        assert cookidoo_cookie.auth_data is None
+
+    async def test_login_discards_stale_token_state(
+        self, mocked: aioresponses, cookidoo_cookie: Cookidoo
+    ) -> None:
+        """A cookie login clears token state left over from a previous OAuth2 login.
+
+        Otherwise the stale bearer header shadows the cookie session and
+        ``_ensure_token`` tries to refresh a token this flow cannot renew,
+        failing every subsequent request with a ``CookidooConfigException``.
+        """
+        cookidoo_cookie.apply_auth_data(
+            CookidooAuthData(
+                access_token="stale-access-token",
+                refresh_token="stale-refresh-token",
+                expires_at=1.0,  # already expired, would trigger a refresh
+            )
+        )
+
+        mocked.get(
+            re.compile(r"https://cookidoo\.ch/profile/de-CH/login.*"),
+            status=HTTPStatus.OK,
+            body=COOKIDOO_TEST_LOGIN_PAGE_HTML,
+        )
+        mocked.post(CIAM_LOGIN_SRV_URL, status=HTTPStatus.OK)
+        cookidoo_cookie._session.cookie_jar.update_cookies(
+            {"_oauth2_proxy": "test-proxy-value", "v-authenticated": "test-auth-value"}
+        )
+
+        await cookidoo_cookie.login()
+
+        assert cookidoo_cookie._auth_mode == "cookie"
+        assert "Authorization" not in cookidoo_cookie._api_headers
+        assert cookidoo_cookie._refresh_token is None
+        assert cookidoo_cookie.auth_data is None
+
+        # The next request must go out on the cookie session alone, without
+        # attempting (and failing) a token refresh.
+        mocked.get(
+            "https://cookidoo.ch/community/profile",
+            status=HTTPStatus.OK,
+            payload=COOKIDOO_TEST_RESPONSE_USER_INFO,
+        )
+        await cookidoo_cookie.get_user_info()
 
     async def test_login_page_unreachable(
         self, mocked: aioresponses, cookidoo_cookie: Cookidoo


### PR DESCRIPTION
Targets `pr-250-oauth-fallback` (#253), not `master`. Three issues I hit while reviewing and testing that branch. Each is a separate commit, so feel free to take only some of them.

I verified both flows live against a real account (login, `get_user_info`, `get_active_subscription`, `get_devices`) before and after each change.

### 1. The two login flows corrupt each other's auth state

`_login_cookie()` sets `_logged_in` but leaves `_api_headers["Authorization"]`, `_refresh_token` and `_expires_at` behind, and `_ensure_token()`/`auth_data` infer the active flow from `_refresh_token is None`. So a cookie login on an instance that had already seen `load_token()`/`apply_auth_data()` still looks like an OAuth2 session. Reproduced live:

```
load_token(<expired token>) -> login()   # no client creds, falls back to cookie, succeeds
get_user_info() -> CookidooConfigException: Missing OAuth2 client credentials in the config: ...
```

A working cookie session is broken by leftover token state, `auth_data` keeps handing back the stale token (so a caller persisting it saves a dead one), and until expiry every request goes out with a `Bearer` header the cookie session doesn't need.

Fixed by tracking the flow explicitly in `_auth_mode` rather than inferring it, and discarding the token state when entering the cookie flow. A regression test covers the exact sequence above — it fails on the current branch head. As a side effect, an OAuth2 login whose token response carries no `refresh_token` no longer silently stops refreshing.

Also hoists the duplicated `{"_oauth2_proxy", "v-authenticated"}` into a `REQUIRED_AUTH_COOKIES` const.

### 2. `example.py` crashes in the fallback mode it documents

The new comment says the cookie session can be persisted "in the same way", but the code still calls `save_token()` after `login()`:

```
save_token: RAISED CookidooConfigException: Cannot save token: not logged in.
```

So `python example.py` without `CLIENT_ID` — now a supported configuration — fails right after a successful login. Now branches on `auth_data` and persists to `.token` or `.cookies`. Checked both paths end to end: fresh login persists, and a second process restores from the file and makes a working API call.

### 3. The PR smoke test cannot run on #253

`pull_request_target` + a bare `actions/checkout` checks out the **base** branch, so stage 1 runs master's code. Master's `smoke_test/test_1_setup_token.py` is still the cookie-based one — it calls `save_cookies(COOKIE_FILE)` and writes `.cookies`, never `.token`. So `cp .token /tmp/.token` fails and kills the job, and `pytest smoke_test/test_1_setup_cookies.py` references a file that doesn't exist on master anyway.

This is inherent to the password-isolation design whenever the auth mechanism itself changes, so rather than weakening it I made stage 1 fail softly and derive from the files it actually produced which stage 2 batches can run, failing the job only if neither login method could prepare a session. On #253 that runs the cookie batch (master's cookie login supplies `.cookies`) and skips the OAuth2 one; once this lands on master both batches run again.

Happy to drop this commit if you'd rather handle the transition manually — it's the one I'm least sure you'll want as-is.

### Not changed, but worth a decision

The title still carries `feat!` while the `20260830` BREAKING_CHANGES section was dropped. With the fallback in place the change looks additive to me: `__init__.py` only adds `CookidooAuthData`, and `save_cookies`/`load_cookies`/`login()`-without-credentials all still work. Either the `!` or an entry describing what does change for callers seems right, but that's your call.

### Checks

`pytest` 304 passed, `mypy` clean, `ruff check` clean. `ruff format` still flags `cookidoo_api/helpers.py:402` — that's pre-existing on master (ruff version drift), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKAEJqv8cQLBjY43yPzKKx
