### PR TITLE
feat!: switch authentication to OAuth2 as a public client (no client secret)

### DIFF
--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -62,7 +62,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             pip install -r requirements_test.txt
-      - name: Prepare cookies with pytest
+      - name: Prepare token with pytest
         run: pytest smoke_test/test_1_setup_token.py -v -x
         env:
           COUNTRY: ${{ matrix.country }}
@@ -73,17 +73,17 @@ jobs:
           EMAIL_IE: ${{ vars.EMAIL_IE }}
           PASSWORD: ${{ secrets.PASSWORD }}
       # !!!!!!!!!!!!!!!!!!!!
-      # From here on, we run new code which does not have access to the password, only the cookies
+      # From here on, we run new code which does not have access to the password, only the token
       # !!!!!!!!!!!!!!!!!!!!
-      - name: Preserve cookies
-        run: cp .cookies /tmp/.cookies
+      - name: Preserve token
+        run: cp .token /tmp/.token
       - name: Checkout new code
         uses: actions/checkout@v7
         with:
           ref: "${{ github.event.pull_request.merge_commit_sha }}"
           clean: false
-      - name: Restore cookies
-        run: cp /tmp/.cookies .cookies
+      - name: Restore token
+        run: cp /tmp/.token .token
       - name: Test with pytest
         run: pytest smoke_test/test_2_methods.py -v -x
         env:

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,6 +2,14 @@
 
 This document tracks the breaking changes observed in the Cookidoo API.
 
+## 20260830
+
+- **Authentication switched to the OAuth2 authorization-code flow (with PKCE).** Requests are authenticated with a `Bearer` token again instead of session cookies. The bearer token also reaches the remote-monitoring backend, which the cookie session could not.
+- **No new credentials to supply.** The flow runs as a public OAuth2 client (PKCE, no client secret), so email and password remain the only inputs. `CookidooConfig` gained `client_id` and `redirect_uri`, both defaulted to the mobile app's public identifiers and both optional. See [docs/oauth-client.md](docs/oauth-client.md).
+- **Token persistence replaces cookie persistence.** Use `save_token(path)` / `load_token(path)` instead of `save_cookies(path)` / `load_cookies(path)`. The tokens are also exposed as a `CookidooAuthData` via the `auth_data` property and can be restored with `apply_auth_data()`.
+- **`refresh()` added.** The access token is refreshed automatically before a request when it is about to expire, and can be refreshed explicitly.
+- `CookieJar(unsafe=True)` is still required, the login redirect chain continues to rely on cookies.
+
 ## 20260508
 
 - **Authentication method changed from password grant to browser OAuth2 flow.** The `grant_type=password` endpoint at `{cc}.tmmobile.vorwerk-digital.com/ciam/auth/token` is deprecated. Authentication now follows the Cookidoo web app's browser-based OAuth2 redirect chain and uses session cookies instead of Bearer tokens.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See below for usage examples.
 
 ## Usage Example
 
-The API is based on the `aiohttp` library. A `CookieJar(unsafe=True)` is required for the session to support cross-domain cookies during the OAuth2 login flow.
+The API is based on the `aiohttp` library. Authentication uses the OAuth2 authorization-code flow (with PKCE) and authenticates requests with a bearer token; tokens can be persisted with `save_token`/`load_token`. A `CookieJar(unsafe=True)` is still required for the session, as the login redirect chain relies on cookies.
 
 Make sure to have stored your credentials in the top-level file `.env` as such, to loaded by `dotenv`. Alternatively, provide the environment variables by any other `dotenv` compatible means.
 
@@ -38,6 +38,8 @@ Make sure to have stored your credentials in the top-level file `.env` as such, 
 EMAIL=your@mail.com
 PASSWORD=password
 ```
+
+Your account credentials are all that is needed. The library logs in as a *public* OAuth2 client — authorization code with PKCE and no client secret — so there is nothing else to obtain or configure. See [OAuth2 client](https://miaucl.github.io/cookidoo-api/oauth-client/) if you want to override the client identifiers anyway.
 
 Run the [example script](https://github.com/miaucl/cookidoo-api/blob/master/example.py) and have a look at the inline comments for more explanation.
 

--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -15,6 +15,7 @@ from .exceptions import (
 from .helpers import get_country_options, get_language_options, get_localization_options
 from .types import (
     CookidooAdditionalItem,
+    CookidooAuthData,
     CookidooCategory,
     CookidooChapter,
     CookidooChapterRecipe,
@@ -46,6 +47,7 @@ __all__ = [
     "CookidooSubscription",
     "CookidooItem",
     "CookidooDevice",
+    "CookidooAuthData",
     "CookidooAdditionalItem",
     "CookidooIngredientItem",
     "CookidooShoppingRecipe",

--- a/cookidoo_api/const.py
+++ b/cookidoo_api/const.py
@@ -20,9 +20,36 @@ LOGIN_HEADERS: Final = {
     ),
 }
 
-CIAM_LOGIN_SRV_URL: Final = (
-    "https://ciam.prod.cookidoo.vorwerk-digital.com/login-srv/login"
-)
+CIAM_BASE_URL: Final = "https://ciam.prod.cookidoo.vorwerk-digital.com"
+CIAM_LOGIN_SRV_URL: Final = f"{CIAM_BASE_URL}/login-srv/login"
+OIDC_DISCOVERY_URL: Final = f"{CIAM_BASE_URL}/.well-known/openid-configuration"
+
+# OAuth2 / OIDC client. The bearer token it yields works against the same
+# api_endpoint as the previous cookie session, and additionally reaches the
+# remote-monitoring backend (which the cookie session could not).
+#
+# The login runs as a *public* client: authorization code + PKCE, with the
+# client id sent in the token request body and no client secret anywhere. CIAM
+# accepts that -- with a `code_verifier` present it does not verify a client
+# secret at all (a request carrying a deliberately wrong secret is accepted just
+# the same), and it rejects the exchange only when neither PKCE nor a secret is
+# supplied. So the secret the mobile app happens to ship is not a credential
+# this flow needs, and nothing secret is embedded here:
+#
+# * the client id is a public identifier by definition -- RFC 6749 sec. 2.2:
+#   "The client identifier is not a secret; it is exposed to the resource owner
+#   and MUST NOT be used alone for client authentication."
+# * the redirect uri is the app's public URL scheme; it travels in the query
+#   string of every authorize request and is declared in the app manifest.
+#
+# Both are overridable via `CookidooConfig` should the app's registration ever
+# change, but callers are not expected to supply anything.
+OAUTH_CLIENT_ID: Final = "mobile-android"
+OAUTH_REDIRECT_URI: Final = "com.vorwerk.cookidoo://code-grant"
+OAUTH_SCOPE: Final = "openid profile email offline offline_access"
+# Refresh a little before the (12h) access token actually expires.
+TOKEN_EXPIRY_MARGIN_S: Final = 300
+
 LOGIN_PATH: Final = "profile/{language}/login"
 LOGIN_REDIRECT: Final = "%2Ffoundation%2F{language}%2Ffor-you"
 RECIPE_PATH: Final = "recipes/recipe/{language}/{id}"

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -29,6 +29,7 @@ from cookidoo_api.const import (
     ADD_RECIPES_TO_CALENDER_PATH,
     ADD_RECIPES_TO_CUSTOM_COLLECTION_PATH,
     ADDITIONAL_ITEMS_PATH,
+    CIAM_BASE_URL,
     CIAM_LOGIN_SRV_URL,
     COMMUNITY_PROFILE_PATH,
     CUSTOM_COLLECTIONS_PATH,
@@ -457,7 +458,7 @@ class Cookidoo:
 
         """
         if self._refresh_token is None:
-            raise CookidooAuthException("Cannot refresh: not logged in.")
+            raise CookidooAuthException("Cannot refresh: no refresh token available.")
         self._assert_oauth_client()
         oidc = await self._discovery()
         try:
@@ -551,12 +552,16 @@ class Cookidoo:
                 if resp.status in (301, 302, 303, 307, 308) and location:
                     if location.startswith(self._cfg.redirect_uri):
                         query = parse_qs(urlparse(location).query)
-                        if query.get("state", [state])[0] != state:
+                        # A missing state is a mismatch: the callback must echo
+                        # the value we sent (RFC 6749 §10.12).
+                        if query.get("state") != [state]:
                             raise CookidooAuthException("OAuth state mismatch.")
                         codes = query.get("code")
                         code = codes[0] if codes else None
                         break
-                    url, method, data = urljoin(url, location), "get", None
+                    url = urljoin(url, location)
+                    self._assert_ciam_origin(url)
+                    method, data = "get", None
                     continue
                 break
         if code is None:
@@ -565,6 +570,20 @@ class Cookidoo:
                 "returned). Please check your email and password."
             )
         return code
+
+    @staticmethod
+    def _assert_ciam_origin(url: str) -> None:
+        """Ensure the login flow never leaves CIAM's own origin.
+
+        The redirect chain carries the session cookies of an in-flight login, so
+        a redirect to a foreign host is refused rather than followed.
+        """
+        origin = urlparse(url)
+        expected = urlparse(CIAM_BASE_URL)
+        if (origin.scheme, origin.netloc) != (expected.scheme, expected.netloc):
+            raise CookidooAuthException(
+                f"Login flow redirected off the authentication host: {url}"
+            )
 
     @staticmethod
     def _check_login_page_status(status: int) -> None:

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -1,18 +1,21 @@
 """Cookidoo api implementation."""
 
+import base64
 from collections.abc import Callable, Mapping, Sequence
 from datetime import date
+import hashlib
 from http import HTTPStatus
-from http.cookies import SimpleCookie
 import json
 from json import JSONDecodeError
 import logging
+import os
 from pathlib import Path
 import re
+import secrets
 import time
 import traceback
 from typing import TypeVar, cast
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from aiohttp import ClientError, ClientSession
 from yarl import URL
@@ -40,10 +43,10 @@ from cookidoo_api.const import (
     EDIT_OWNERSHIP_INGREDIENT_ITEMS_PATH,
     INGREDIENT_ITEMS_PATH,
     LOGIN_HEADERS,
-    LOGIN_PATH,
-    LOGIN_REDIRECT,
     MANAGED_COLLECTIONS_PATH,
     MANAGED_COLLECTIONS_PATH_ACCEPT,
+    OAUTH_SCOPE,
+    OIDC_DISCOVERY_URL,
     RECIPE_PATH,
     RECIPES_IN_CALENDAR_WEEK_PATH,
     REMOVE_ADDITIONAL_ITEMS_PATH,
@@ -55,6 +58,7 @@ from cookidoo_api.const import (
     REMOVE_RECIPE_FROM_CUSTOM_COLLECTION_PATH,
     SHOPPING_LIST_RECIPES_PATH,
     SUBSCRIPTIONS_PATH,
+    TOKEN_EXPIRY_MARGIN_S,
 )
 from cookidoo_api.exceptions import (
     CookidooAuthException,
@@ -94,6 +98,7 @@ from cookidoo_api.raw_types import (
 )
 from cookidoo_api.types import (
     CookidooAdditionalItem,
+    CookidooAuthData,
     CookidooCalendarDay,
     CookidooCollection,
     CookidooConfig,
@@ -120,6 +125,9 @@ class Cookidoo:
     _cfg: CookidooConfig
     _api_headers: dict[str, str]
     _logged_in: bool
+    _refresh_token: str | None
+    _expires_at: float
+    _oidc: dict[str, str] | None
 
     def __init__(
         self,
@@ -142,6 +150,9 @@ class Cookidoo:
         self._cfg = cfg
         self._api_headers = DEFAULT_API_HEADERS.copy()
         self._logged_in = False
+        self._refresh_token = None
+        self._expires_at = 0.0
+        self._oidc = None
 
     @property
     def localization(self) -> CookidooLocalizationConfig:
@@ -210,6 +221,7 @@ class Cookidoo:
             When the response body cannot be parsed as JSON.
 
         """
+        await self._ensure_token()
         merged_headers = {**self._api_headers, **(headers or {})}
 
         try:
@@ -328,26 +340,51 @@ class Cookidoo:
             recipes=[],
         )
 
+    @property
+    def auth_data(self) -> CookidooAuthData | None:
+        """The current OAuth2 tokens, for persistence. ``None`` until logged in."""
+        if not self._logged_in or self._refresh_token is None:
+            return None
+        return CookidooAuthData(
+            access_token=self._api_headers["Authorization"].removeprefix("Bearer "),
+            refresh_token=self._refresh_token,
+            expires_at=self._expires_at,
+        )
+
+    def apply_auth_data(self, auth_data: CookidooAuthData) -> None:
+        """Restore a previous login from persisted tokens (no network call).
+
+        The access token is refreshed automatically on the next request if it
+        has expired.
+        """
+        self._api_headers["Authorization"] = f"Bearer {auth_data.access_token}"
+        self._refresh_token = auth_data.refresh_token
+        self._expires_at = auth_data.expires_at
+        self._logged_in = True
+
     async def login(self) -> None:
-        """Perform browser-based OAuth2 login.
+        """Perform an OAuth2 authorization-code + PKCE login.
 
-        Follows the same redirect chain as the Cookidoo web app:
-        1. Initiate login at ``cookidoo.{tld}/profile/{lang}/login``
-        2. Follow redirects through OAuth2/PKCE to the CIAM login page
-        3. POST credentials to the CIAM login service
-        4. Follow callback redirects to capture session cookies
+        Signs in with the configured email/password against the CIAM identity
+        provider, exchanges the resulting code for an access/refresh token, and
+        authenticates all subsequent API calls via a ``Bearer`` header:
 
-        After login, the session's cookie jar contains the authentication
-        cookies and all subsequent API calls are authenticated automatically.
+        1. discover the OIDC endpoints
+        2. open the authorize endpoint to reach the CIAM login form
+        3. POST the credentials to the CIAM login service
+        4. capture the ``code`` from the redirect to the app scheme
+        5. exchange the code for tokens (public client, PKCE, no secret)
 
-        The login requests are sent with a browser-like ``User-Agent``
-        (request-scoped only, the session's own defaults are left untouched)
-        since the login flow is served behind Cloudflare, which is more
-        likely to challenge/block requests carrying a non-browser
-        User-Agent (e.g. a generic HTTP client's default).
+        The login redirects still rely on the session cookie jar, so a
+        ``CookieJar(unsafe=True)`` session is required. The login requests carry
+        a browser-like ``User-Agent`` (request-scoped only) since the flow is
+        served behind Cloudflare.
 
         Raises
         ------
+        CookidooConfigException
+            If the OAuth2 client id or redirect uri was overridden with an
+            empty value.
         CookidooRequestException
             If the request fails.
         CookidooParseException
@@ -356,50 +393,43 @@ class Cookidoo:
             If the login fails due to invalid credentials.
 
         """
-        language = self._cfg.localization.language
-        login_path = LOGIN_PATH.format(language=language)
-        redirect = LOGIN_REDIRECT.format(language=language)
-        login_url = URL(
-            str(self.api_endpoint / login_path) + f"?redirectAfterLogin={redirect}",
-            encoded=True,
-        )
-
+        self._assert_oauth_client()
         try:
-            # Step 1: Follow redirect chain to reach the CIAM login page
+            oidc = await self._discovery()
+            verifier, challenge = self._pkce_pair()
+            state = secrets.token_urlsafe(12)
+            language = self._cfg.localization.language
+            params = {
+                "response_type": "code",
+                "client_id": self._cfg.client_id,
+                "redirect_uri": self._cfg.redirect_uri,
+                "market": self._cfg.localization.country_code,
+                "scope": OAUTH_SCOPE,
+                "state": state,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "ui_locales": language,
+            }
+
+            # Step 2: reach the CIAM login form (follows redirects, sets cookies)
             async with self._session.get(
-                login_url, allow_redirects=True, headers=LOGIN_HEADERS
+                URL(oidc["authorization_endpoint"]),
+                params=params,
+                allow_redirects=True,
+                headers=LOGIN_HEADERS,
             ) as resp:
                 self._check_login_page_status(resp.status)
                 login_html = await resp.text()
 
-            # Step 2: Extract requestId from the login form
+            # Step 3: submit credentials, Step 4: capture the authorization code
             request_id = self._extract_request_id(login_html)
+            code = await self._submit_credentials(request_id, state)
 
-            # Step 3: POST credentials to CIAM login service
-            login_data = {
-                "requestId": request_id,
-                "username": self._cfg.email,
-                "password": self._cfg.password,
-            }
-            async with self._session.post(
-                CIAM_LOGIN_SRV_URL,
-                data=login_data,
-                allow_redirects=True,
-                headers=LOGIN_HEADERS,
-            ) as resp:
-                _LOGGER.debug(
-                    "Login POST completed, final URL: %s (status: %s)",
-                    resp.url,
-                    resp.status,
-                )
-
-            # Step 4: Verify authentication cookies were set
-            self._verify_auth_cookies()
+            # Step 5: exchange the code for tokens
+            await self._exchange_code(oidc["token_endpoint"], code, verifier)
             self._logged_in = True
 
-        except CookidooAuthException:
-            raise
-        except CookidooParseException:
+        except (CookidooAuthException, CookidooParseException):
             raise
         except TimeoutError as e:
             _LOGGER.debug("Exception: Login failed:\n %s", traceback.format_exc())
@@ -412,12 +442,213 @@ class Cookidoo:
                 "Authentication failed due to request exception."
             ) from e
 
+    async def refresh(self) -> None:
+        """Refresh the access token using the stored refresh token.
+
+        Raises
+        ------
+        CookidooAuthException
+            If there is no refresh token or the refresh is rejected.
+        CookidooConfigException
+            If the OAuth2 client id or redirect uri was overridden with an
+            empty value.
+        CookidooRequestException
+            If the request fails.
+
+        """
+        if self._refresh_token is None:
+            raise CookidooAuthException("Cannot refresh: not logged in.")
+        self._assert_oauth_client()
+        oidc = await self._discovery()
+        try:
+            async with self._session.post(
+                URL(oidc["token_endpoint"]),
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": self._refresh_token,
+                    "client_id": self._cfg.client_id,
+                },
+                headers=LOGIN_HEADERS,
+            ) as resp:
+                if resp.status != HTTPStatus.OK:
+                    raise CookidooAuthException(
+                        f"Token refresh failed (status {resp.status})."
+                    )
+                payload = cast(dict[str, object], await resp.json())
+        except ClientError as e:
+            raise CookidooRequestException(
+                "Token refresh failed due to request exception."
+            ) from e
+        self._apply_tokens(payload)
+
+    def save_token(self, path: str | Path) -> None:
+        """Save the OAuth2 tokens to a file for later reuse.
+
+        Parameters
+        ----------
+        path
+            Path to the file where the tokens will be saved.
+
+        """
+        if (auth_data := self.auth_data) is None:
+            raise CookidooConfigException("Cannot save token: not logged in.")
+        Path(path).write_text(json.dumps(vars(auth_data)), encoding="utf-8")
+
+    def load_token(self, path: str | Path) -> None:
+        """Restore the OAuth2 tokens from a file saved with :meth:`save_token`.
+
+        Parameters
+        ----------
+        path
+            Path to the file containing the saved tokens.
+
+        Raises
+        ------
+        CookidooConfigException
+            If the token file cannot be read or parsed.
+
+        """
+        try:
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+            self.apply_auth_data(CookidooAuthData(**data))
+        except (OSError, json.JSONDecodeError, TypeError) as e:
+            raise CookidooConfigException(f"Cannot load token from {path}.") from e
+
+    # -- internal auth helpers --------------------------------------------
+    async def _discovery(self) -> dict[str, str]:
+        """Fetch and cache the OIDC discovery document."""
+        if self._oidc is None:
+            async with self._session.get(
+                URL(OIDC_DISCOVERY_URL), headers=LOGIN_HEADERS
+            ) as resp:
+                resp.raise_for_status()
+                self._oidc = cast(dict[str, str], await resp.json())
+        return self._oidc
+
+    async def _submit_credentials(self, request_id: str, state: str) -> str:
+        """POST credentials and follow the redirect chain to capture the code.
+
+        Raises ``CookidooAuthException`` when no authorization code is returned
+        (i.e. the credentials were rejected).
+        """
+        url: str = CIAM_LOGIN_SRV_URL
+        data: dict[str, str] | None = {
+            "requestId": request_id,
+            "username": self._cfg.email,
+            "password": self._cfg.password,
+        }
+        method = "post"
+        code: str | None = None
+        for _ in range(10):
+            async with self._session.request(
+                method,
+                URL(url),
+                data=data,
+                headers=LOGIN_HEADERS,
+                allow_redirects=False,
+            ) as resp:
+                location = resp.headers.get("Location")
+                if resp.status in (301, 302, 303, 307, 308) and location:
+                    if location.startswith(self._cfg.redirect_uri):
+                        query = parse_qs(urlparse(location).query)
+                        if query.get("state", [state])[0] != state:
+                            raise CookidooAuthException("OAuth state mismatch.")
+                        codes = query.get("code")
+                        code = codes[0] if codes else None
+                        break
+                    url, method, data = urljoin(url, location), "get", None
+                    continue
+                break
+        if code is None:
+            raise CookidooAuthException(
+                "Login failed: invalid credentials (no authorization code "
+                "returned). Please check your email and password."
+            )
+        return code
+
     @staticmethod
     def _check_login_page_status(status: int) -> None:
         """Check login page response status."""
         if status != HTTPStatus.OK:
             raise CookidooAuthException(
                 f"Login flow failed: could not reach login page (status {status})."
+            )
+
+    async def _exchange_code(
+        self, token_endpoint: str, code: str, verifier: str
+    ) -> None:
+        """Exchange an authorization code for tokens."""
+        async with self._session.post(
+            URL(token_endpoint),
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self._cfg.redirect_uri,
+                "code_verifier": verifier,
+                "client_id": self._cfg.client_id,
+            },
+            headers=LOGIN_HEADERS,
+        ) as resp:
+            if resp.status != HTTPStatus.OK:
+                raise CookidooAuthException(
+                    f"Token exchange failed (status {resp.status})."
+                )
+            payload = cast(dict[str, object], await resp.json())
+        self._apply_tokens(payload)
+
+    def _apply_tokens(self, payload: dict[str, object]) -> None:
+        """Store tokens from a token-endpoint response and set the auth header."""
+        try:
+            access_token = cast(str, payload["access_token"])
+            # A refresh response may omit a new refresh token; keep the old one.
+            self._refresh_token = cast(
+                str, payload.get("refresh_token", self._refresh_token)
+            )
+            expires_in = int(cast(int, payload.get("expires_in", 43200)))
+        except (KeyError, TypeError, ValueError) as e:
+            raise CookidooAuthException(f"Unexpected token response: {payload}") from e
+        self._api_headers["Authorization"] = f"Bearer {access_token}"
+        self._expires_at = time.time() + expires_in
+
+    async def _ensure_token(self) -> None:
+        """Refresh the access token if it is missing or about to expire."""
+        if not self._logged_in:
+            return
+        if time.time() >= self._expires_at - TOKEN_EXPIRY_MARGIN_S:
+            await self.refresh()
+
+    @staticmethod
+    def _pkce_pair() -> tuple[str, str]:
+        """Return a (code_verifier, code_challenge) PKCE S256 pair."""
+        verifier = base64.urlsafe_b64encode(os.urandom(48)).rstrip(b"=").decode()
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        return verifier, challenge
+
+    def _assert_oauth_client(self) -> None:
+        """Ensure the OAuth2 client identifiers are set.
+
+        Both default to the mobile app's public identifiers, so this only trips
+        when a caller overrides one of them with an empty value.
+
+        Raises
+        ------
+        CookidooConfigException
+            If the client id or the redirect uri is missing.
+
+        """
+        missing = [
+            name
+            for name in ("client_id", "redirect_uri")
+            if not getattr(self._cfg, name)
+        ]
+        if missing:
+            raise CookidooConfigException(
+                f"Missing OAuth2 client configuration: {', '.join(missing)}. "
+                "Leave these unset to use the defaults, see docs/oauth-client.md."
             )
 
     @staticmethod
@@ -435,71 +666,6 @@ class Cookidoo:
                 "Login flow failed: could not extract requestId from login page."
             )
         return match.group(1)
-
-    def _verify_auth_cookies(self) -> None:
-        """Verify that required authentication cookies are present."""
-        cookie_names = {c.key for c in self._session.cookie_jar}
-        required_cookies = {"_oauth2_proxy", "v-authenticated"}
-        if not required_cookies.issubset(cookie_names):
-            raise CookidooAuthException(
-                "Login failed: authentication cookies were not set. "
-                "Please check your email and password."
-            )
-
-    def save_cookies(self, path: str | Path) -> None:
-        """Save session cookies to a file for later reuse.
-
-        Parameters
-        ----------
-        path
-            Path to the file where cookies will be saved.
-
-        """
-        cookies: list[dict[str, str]] = []
-        for cookie in self._session.cookie_jar:
-            cookies.append(
-                {
-                    "key": cookie.key,
-                    "value": cookie.value,
-                    "domain": cookie["domain"],
-                    "path": cookie["path"],
-                }
-            )
-        Path(path).write_text(json.dumps(cookies), encoding="utf-8")
-
-    def load_cookies(self, path: str | Path) -> None:
-        """Load session cookies from a file to restore a previous session.
-
-        Parameters
-        ----------
-        path
-            Path to the file containing saved cookies.
-
-        Raises
-        ------
-        CookidooConfigException
-            If the cookie file cannot be read or parsed.
-
-        """
-        try:
-            data = json.loads(Path(path).read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as e:
-            raise CookidooConfigException(f"Cannot load cookies from {path}.") from e
-
-        for entry in data:
-            cookie: SimpleCookie = SimpleCookie()
-            cookie[entry["key"]] = entry["value"]
-            cookie[entry["key"]]["domain"] = entry.get("domain", "")
-            cookie[entry["key"]]["path"] = entry.get("path", "/")
-            self._session.cookie_jar.update_cookies(
-                cookie, URL(f"https://{entry.get('domain', '')}")
-            )
-
-        # Check if required auth cookies are present
-        cookie_names = {c.key for c in self._session.cookie_jar}
-        required_cookies = {"_oauth2_proxy", "v-authenticated"}
-        if required_cookies.issubset(cookie_names):
-            self._logged_in = True
 
     async def get_user_info(
         self,

--- a/cookidoo_api/types.py
+++ b/cookidoo_api/types.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from cookidoo_api.const import OAUTH_CLIENT_ID, OAUTH_REDIRECT_URI
+
 
 class ThermomixMachineType(StrEnum):
     """Thermomix machine types."""
@@ -34,6 +36,15 @@ class CookidooConfig:
         The email to login
     password
         The password to login
+    client_id
+        The OAuth2 client id to run the login flow as
+    redirect_uri
+        The OAuth2 redirect uri registered for ``client_id``
+
+    The login runs as a public client (authorization code + PKCE, no client
+    secret), so both values are public identifiers rather than credentials and
+    they default to the ones of the Cookidoo mobile app. Callers do not need to
+    set them; see ``docs/oauth-client.md``.
 
     """
 
@@ -42,6 +53,8 @@ class CookidooConfig:
     )
     email: str = "your@email"
     password: str = "1234password!"
+    client_id: str = OAUTH_CLIENT_ID
+    redirect_uri: str = OAUTH_REDIRECT_URI
 
 
 @dataclass
@@ -73,6 +86,18 @@ class CookidooDevice:
     """A paired Thermomix appliance on the account."""
 
     type: ThermomixMachineType
+
+
+@dataclass
+class CookidooAuthData:
+    """OAuth2 tokens obtained from a login, for persistence and restore.
+
+    ``expires_at`` is a POSIX timestamp (seconds) for the access token.
+    """
+
+    access_token: str
+    refresh_token: str
+    expires_at: float
 
 
 @dataclass

--- a/docs/oauth-client.md
+++ b/docs/oauth-client.md
@@ -1,0 +1,91 @@
+# OAuth2 client
+
+The login uses the OAuth2 **authorization code** flow with **PKCE**, run as a
+**public client**: there is no client secret, and nothing you need to obtain.
+Your Cookidoo account is the only credential:
+
+```python
+from cookidoo_api import Cookidoo, CookidooConfig
+
+cookidoo = Cookidoo(
+    session,
+    cfg=CookidooConfig(
+        email=os.environ["EMAIL"],
+        password=os.environ["PASSWORD"],
+    ),
+)
+```
+
+## Why there is no secret
+
+An OAuth2 client is identified by a **client id** and a **redirect uri**, and
+*may* additionally authenticate itself with a **client secret**. The Cookidoo
+identity provider (CIAM, a cidaas deployment) does not require the third one
+here: when the token request carries a PKCE `code_verifier`, the client secret
+is not verified at all.
+
+Observed against the production token endpoint, exchanging the same
+authorization code:
+
+| token request | result |
+| --- | --- |
+| `client_id` + `code_verifier`, no secret | `200` — token |
+| `client_id` + `code_verifier` + *wrong* secret | `200` — token |
+| `client_id` + `code_verifier` + correct secret | `200` — token |
+| `client_id`, **no** `code_verifier`, no secret | `400 invalid_client` |
+| `code_verifier`, no `client_id` | `400 invalid_client` |
+
+A deliberately wrong secret being accepted is the decisive one: the secret is
+not part of what the server checks. It is PKCE that binds the exchange to the
+client instance that started the flow — which is exactly what PKCE exists for,
+and why [RFC 8252][rfc8252] prescribes this shape for native apps, whose
+"secrets" cannot stay secret in a distributed binary anyway.
+
+So the library sends the client id in the token request body and no
+`Authorization` header, and the resulting bearer token is indistinguishable
+from one obtained with a secret — same audience, same scopes, same roles, and
+the same access to both the Cookidoo API and the remote-monitoring (`iot-api`)
+backend.
+
+## What is shipped, and why that is not a secret
+
+Two values are built in as defaults:
+
+- `client_id` — `mobile-android`. A client id is a public identifier by
+  definition. [RFC 6749 §2.2][rfc6749-2.2]: *"The client identifier is not a
+  secret; it is exposed to the resource owner and MUST NOT be used alone for
+  client authentication."*
+- `redirect_uri` — `com.vorwerk.cookidoo://code-grant`. The app's URL scheme.
+  It travels in the query string of every authorize request, is declared in the
+  app manifest, and is registered with the provider precisely so it can be
+  matched publicly.
+
+Neither is a credential, so neither is withheld from you or from this
+repository.
+
+## Overriding them
+
+They are still plain config fields, should the app's registration ever change
+before this library catches up:
+
+```python
+CookidooConfig(
+    email=...,
+    password=...,
+    client_id="mobile-ios",
+    redirect_uri="com.vorwerk.cookidoo://code-grant",
+)
+```
+
+Setting either to an empty string raises `CookidooConfigException` at `login()`
+rather than producing a confusing `invalid_client` from the server.
+
+If the authorize step starts rejecting the built-in client id, the app's
+registration has changed. The current value can be read back out of a copy of
+the app you own: the client id is a short kebab identifier and the redirect uri
+a custom URI scheme, both plain strings in the APK's `classes*.dex` string
+pools and its manifest. Please open an issue so the default can be updated for
+everyone.
+
+[rfc6749-2.2]: https://datatracker.ietf.org/doc/html/rfc6749#section-2.2
+[rfc8252]: https://datatracker.ietf.org/doc/html/rfc8252#section-8.5

--- a/example.py
+++ b/example.py
@@ -45,7 +45,9 @@ async def main():
         _localizations_ch = await get_localization_options(country="ch")
         _localizations_en = await get_localization_options(language="en")
 
-        # Create Cookidoo instance with email and password
+        # Create Cookidoo instance with email and password. The OAuth2 client
+        # identifiers default to the mobile app's public ones, nothing else to
+        # configure (see docs/oauth-client.md)
         cookidoo = Cookidoo(
             session,
             cfg=CookidooConfig(
@@ -57,13 +59,13 @@ async def main():
             ),
         )
 
-        # Try to load saved cookies, otherwise login fresh
-        cookie_file = ".cookies"
+        # Try to reuse a saved token, otherwise login fresh
+        token_file = ".token"
         try:
-            cookidoo.load_cookies(cookie_file)
+            cookidoo.load_token(token_file)
         except Exception:
             await cookidoo.login()
-            cookidoo.save_cookies(cookie_file)
+            cookidoo.save_token(token_file)
 
         # Info
         await cookidoo.get_user_info()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,3 +68,4 @@ nav:
     - License: license.md
     - Reference: reference.md
     - Localization: localization.md
+    - OAuth2 client: oauth-client.md

--- a/smoke_test/conftest.py
+++ b/smoke_test/conftest.py
@@ -14,7 +14,7 @@ from cookidoo_api.types import CookidooConfig
 
 load_dotenv()
 
-COOKIE_FILE = Path(".cookies")
+TOKEN_FILE = Path(".token")
 
 
 @pytest.fixture(name="session")
@@ -47,7 +47,7 @@ async def cookidoo_api_client_no_auth(session: ClientSession) -> Cookidoo:
 async def cookidoo_authenticated_api_client(
     session: ClientSession,
 ) -> Cookidoo:
-    """Create authenticated Cookidoo instance from saved cookies."""
+    """Create authenticated Cookidoo instance from a saved token."""
 
     country = os.environ["COUNTRY"]
     localizations = await get_localization_options(country=country)
@@ -61,7 +61,7 @@ async def cookidoo_authenticated_api_client(
         ),
     )
 
-    # Restore session from saved cookies
-    cookidoo.load_cookies(COOKIE_FILE)
+    # Restore session from a saved token
+    cookidoo.load_token(TOKEN_FILE)
 
     return cookidoo

--- a/smoke_test/test_1_setup_token.py
+++ b/smoke_test/test_1_setup_token.py
@@ -1,14 +1,14 @@
 """Setup login for smoke test for cookidoo-api."""
 
 from cookidoo_api.cookidoo import Cookidoo
-from smoke_test.conftest import COOKIE_FILE
+from smoke_test.conftest import TOKEN_FILE
 
 
 class TestLoginAndValidation:
     """Test login and validation."""
 
     async def test_cookidoo_login(self, cookidoo_no_auth: Cookidoo) -> None:
-        """Test cookidoo login via browser OAuth2 flow and save cookies."""
+        """Test cookidoo login via OAuth2 flow and save the token."""
         await cookidoo_no_auth.login()
         assert cookidoo_no_auth._logged_in
-        cookidoo_no_auth.save_cookies(COOKIE_FILE)
+        cookidoo_no_auth.save_token(TOKEN_FILE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,15 @@ from dotenv import load_dotenv
 import pytest
 
 from cookidoo_api.cookidoo import Cookidoo
+from cookidoo_api.types import CookidooConfig
 
 load_dotenv()
 
 UUID = "00000000-00000000-00000000-00000000"
+
+# Dummy OAuth2 client, so the tests do not depend on the shipped defaults.
+TEST_CLIENT_ID = "test-client-id"
+TEST_REDIRECT_URI = "test.cookidoo.api://code-grant"
 
 
 @pytest.fixture(name="session")
@@ -25,7 +30,13 @@ async def aiohttp_client_session() -> AsyncGenerator[ClientSession]:
 @pytest.fixture(name="cookidoo")
 async def bring_api_client(session: ClientSession) -> Cookidoo:
     """Create Cookidoo instance."""
-    cookidoo = Cookidoo(session)
+    cookidoo = Cookidoo(
+        session,
+        cfg=CookidooConfig(
+            client_id=TEST_CLIENT_ID,
+            redirect_uri=TEST_REDIRECT_URI,
+        ),
+    )
     return cookidoo
 
 

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -86,6 +86,30 @@ COOKIDOO_TEST_RESPONSE_INACTIVE_SUBSCRIPTION: Final = [
     }
 ]
 
+COOKIDOO_TEST_OIDC_DISCOVERY: Final = {
+    "authorization_endpoint": (
+        "https://ciam.prod.cookidoo.vorwerk-digital.com/authz-srv/authz"
+    ),
+    "token_endpoint": (
+        "https://ciam.prod.cookidoo.vorwerk-digital.com/token-srv/token"
+    ),
+}
+
+COOKIDOO_TEST_TOKEN_RESPONSE: Final = {
+    "access_token": "test-access-token",
+    "refresh_token": "test-refresh-token",
+    "id_token": "test-id-token",
+    "token_type": "Bearer",
+    "expires_in": 43200,
+}
+
+COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE: Final = {
+    "access_token": "refreshed-access-token",
+    "refresh_token": "refreshed-refresh-token",
+    "token_type": "Bearer",
+    "expires_in": 43200,
+}
+
 COOKIDOO_TEST_RESPONSE_DEVICES: Final = ["TM7"]
 
 COOKIDOO_TEST_RESPONSE_DEVICES_MULTIPLE: Final = ["TM7", "TM6"]

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -1,12 +1,14 @@
 """Unit tests for cookidoo-api."""
 
+from collections.abc import Callable
 from datetime import datetime
 from http import HTTPStatus
 import pathlib
 import re
+from typing import Any
 
 from aiohttp import ClientError, ClientSession
-from aioresponses import aioresponses
+from aioresponses import CallbackResult, aioresponses
 from dotenv import load_dotenv
 import pytest
 from yarl import URL
@@ -125,23 +127,48 @@ class TestLogin:
     """Tests for the OAuth2 authorization-code login flow."""
 
     @staticmethod
+    def _mock_authorize(
+        mocked: aioresponses, *, body: str = COOKIDOO_TEST_LOGIN_PAGE_HTML
+    ) -> dict[str, str]:
+        """Serve the login page and capture the ``state`` the client sent."""
+        captured: dict[str, str] = {}
+
+        def _serve(url: URL, **kwargs: Any) -> CallbackResult:
+            captured["state"] = url.query["state"]
+            return CallbackResult(status=HTTPStatus.OK, body=body)
+
+        mocked.get(AUTHZ_RE, callback=_serve, repeat=True)
+        return captured
+
+    @staticmethod
+    def _app_redirect(
+        captured: dict[str, str], *, code: str | None = "test-code"
+    ) -> Callable[..., CallbackResult]:
+        """Redirect to the app scheme, echoing the state like CIAM does."""
+
+        def _redirect(url: URL, **kwargs: Any) -> CallbackResult:
+            query = [f"code={code}"] if code else []
+            query.append(f"state={captured['state']}")
+            return CallbackResult(
+                status=HTTPStatus.FOUND,
+                headers={"Location": f"{TEST_REDIRECT_URI}?{'&'.join(query)}"},
+            )
+
+        return _redirect
+
+    @classmethod
     def _mock_login_flow(
+        cls,
         mocked: aioresponses,
         *,
         page_body: str = COOKIDOO_TEST_LOGIN_PAGE_HTML,
         code: str | None = "test-code",
-    ) -> None:
+    ) -> dict[str, str]:
         mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
-        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=page_body)
-        location = TEST_REDIRECT_URI
-        if code:
-            location += f"?code={code}"
-        mocked.post(
-            CIAM_LOGIN_SRV_URL,
-            status=HTTPStatus.FOUND,
-            headers={"Location": location},
-        )
+        captured = cls._mock_authorize(mocked, body=page_body)
+        mocked.post(CIAM_LOGIN_SRV_URL, callback=cls._app_redirect(captured, code=code))
         mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_TOKEN_RESPONSE)
+        return captured
 
     async def test_login_success(
         self, mocked: aioresponses, cookidoo: Cookidoo
@@ -231,7 +258,7 @@ class TestLogin:
     ) -> None:
         """Redirects before the app scheme are followed to capture the code."""
         mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
-        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        captured = self._mock_authorize(mocked)
         interstitial = (
             "https://ciam.prod.cookidoo.vorwerk-digital.com/login-srv/continue"
         )
@@ -240,23 +267,36 @@ class TestLogin:
             status=HTTPStatus.FOUND,
             headers={"Location": interstitial},
         )
-        mocked.get(
-            interstitial,
-            status=HTTPStatus.FOUND,
-            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
-        )
+        mocked.get(interstitial, callback=self._app_redirect(captured))
         mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_TOKEN_RESPONSE)
 
         await cookidoo.login()
 
         assert cookidoo._logged_in
 
+    async def test_login_refuses_redirect_off_the_auth_host(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A redirect leaving the CIAM origin is refused instead of followed."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        self._mock_authorize(mocked)
+        mocked.post(
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": "https://evil.example/login-srv/continue"},
+        )
+
+        with pytest.raises(
+            CookidooAuthException, match="redirected off the authentication host"
+        ):
+            await cookidoo.login()
+
     async def test_login_state_mismatch(
         self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:
         """A state that does not match the one sent aborts the login."""
         mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
-        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        self._mock_authorize(mocked)
         mocked.post(
             CIAM_LOGIN_SRV_URL,
             status=HTTPStatus.FOUND,
@@ -265,6 +305,35 @@ class TestLogin:
 
         with pytest.raises(CookidooAuthException, match="state mismatch"):
             await cookidoo.login()
+
+    async def test_login_state_missing(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A callback that omits the state entirely counts as a mismatch."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        self._mock_authorize(mocked)
+        mocked.post(
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
+        )
+
+        with pytest.raises(CookidooAuthException, match="state mismatch"):
+            await cookidoo.login()
+
+    async def test_login_sends_the_state_it_verifies(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """The state accepted on the callback is the one the client sent."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        captured = self._mock_authorize(mocked)
+        mocked.post(CIAM_LOGIN_SRV_URL, callback=self._app_redirect(captured))
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_TOKEN_RESPONSE)
+
+        await cookidoo.login()
+
+        assert captured["state"]
+        assert cookidoo._logged_in
 
     async def test_login_redirect_loop(
         self, mocked: aioresponses, cookidoo: Cookidoo
@@ -293,12 +362,8 @@ class TestLogin:
     ) -> None:
         """A rejected code exchange surfaces as an auth exception."""
         mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
-        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
-        mocked.post(
-            CIAM_LOGIN_SRV_URL,
-            status=HTTPStatus.FOUND,
-            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
-        )
+        captured = self._mock_authorize(mocked)
+        mocked.post(CIAM_LOGIN_SRV_URL, callback=self._app_redirect(captured))
         mocked.post(TOKEN_ENDPOINT, status=HTTPStatus.BAD_REQUEST)
 
         with pytest.raises(CookidooAuthException, match="Token exchange failed"):
@@ -309,12 +374,8 @@ class TestLogin:
     ) -> None:
         """A token response without an access token surfaces as an auth exception."""
         mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
-        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
-        mocked.post(
-            CIAM_LOGIN_SRV_URL,
-            status=HTTPStatus.FOUND,
-            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
-        )
+        captured = self._mock_authorize(mocked)
+        mocked.post(CIAM_LOGIN_SRV_URL, callback=self._app_redirect(captured))
         mocked.post(TOKEN_ENDPOINT, payload={"token_type": "Bearer"})
 
         with pytest.raises(CookidooAuthException, match="Unexpected token response"):
@@ -324,17 +385,12 @@ class TestLogin:
         self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:
         """The OIDC discovery document is only fetched once."""
-        self._mock_login_flow(mocked)
+        captured = self._mock_login_flow(mocked)
 
         await cookidoo.login()
         # A second login must not hit the discovery endpoint again, it is only
         # mocked once and a second request would fail.
-        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
-        mocked.post(
-            CIAM_LOGIN_SRV_URL,
-            status=HTTPStatus.FOUND,
-            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
-        )
+        mocked.post(CIAM_LOGIN_SRV_URL, callback=self._app_redirect(captured))
         mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_TOKEN_RESPONSE)
 
         await cookidoo.login()
@@ -447,8 +503,8 @@ class TestTokenPersistenceAndRefresh:
         assert cookidoo.auth_data.refresh_token == "refreshed-refresh-token"
 
     async def test_refresh_without_login(self, cookidoo: Cookidoo) -> None:
-        """Refreshing without a login raises."""
-        with pytest.raises(CookidooAuthException, match="not logged in"):
+        """Refreshing without a refresh token raises."""
+        with pytest.raises(CookidooAuthException, match="no refresh token available"):
             await cookidoo.refresh()
 
     async def test_refresh_rejected(

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -2,15 +2,25 @@
 
 from datetime import datetime
 from http import HTTPStatus
+import pathlib
+import re
 
 from aiohttp import ClientError, ClientSession
 from aioresponses import aioresponses
 from dotenv import load_dotenv
 import pytest
+from yarl import URL
 
+from cookidoo_api.const import (
+    CIAM_LOGIN_SRV_URL,
+    OAUTH_CLIENT_ID,
+    OAUTH_REDIRECT_URI,
+    OIDC_DISCOVERY_URL,
+)
 from cookidoo_api.cookidoo import Cookidoo
 from cookidoo_api.exceptions import (
     CookidooAuthException,
+    CookidooConfigException,
     CookidooException,
     CookidooParseException,
     CookidooRequestException,
@@ -18,13 +28,17 @@ from cookidoo_api.exceptions import (
 from cookidoo_api.helpers import get_localization_options
 from cookidoo_api.types import (
     CookidooAdditionalItem,
+    CookidooAuthData,
     CookidooConfig,
     CookidooIngredientItem,
     CookidooSearchResult,
     ThermomixMachineType,
 )
+from tests.conftest import TEST_CLIENT_ID, TEST_REDIRECT_URI
 from tests.responses import (
     COOKIDOO_TEST_LOGIN_PAGE_HTML,
+    COOKIDOO_TEST_OIDC_DISCOVERY,
+    COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE,
     COOKIDOO_TEST_RESPONSE_ACTIVE_SUBSCRIPTION,
     COOKIDOO_TEST_RESPONSE_ADD_ADDITIONAL_ITEMS,
     COOKIDOO_TEST_RESPONSE_ADD_CUSTOM_COLLECTION,
@@ -57,6 +71,7 @@ from tests.responses import (
     COOKIDOO_TEST_RESPONSE_REMOVE_RECIPE_FROM_CUSTOM_COLLECTION,
     COOKIDOO_TEST_RESPONSE_SEARCH_RECIPES,
     COOKIDOO_TEST_RESPONSE_USER_INFO,
+    COOKIDOO_TEST_TOKEN_RESPONSE,
 )
 
 load_dotenv()
@@ -102,46 +117,85 @@ class TestGetterSetter:
         assert loc.country_code == "ch"
 
 
+TOKEN_ENDPOINT = "https://ciam.prod.cookidoo.vorwerk-digital.com/token-srv/token"
+AUTHZ_RE = re.compile(r".*/authz-srv/authz.*")
+
+
 class TestLogin:
-    """Tests for login method."""
+    """Tests for the OAuth2 authorization-code login flow."""
+
+    @staticmethod
+    def _mock_login_flow(
+        mocked: aioresponses,
+        *,
+        page_body: str = COOKIDOO_TEST_LOGIN_PAGE_HTML,
+        code: str | None = "test-code",
+    ) -> None:
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=page_body)
+        location = TEST_REDIRECT_URI
+        if code:
+            location += f"?code={code}"
+        mocked.post(
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": location},
+        )
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_TOKEN_RESPONSE)
 
     async def test_login_success(
         self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:
-        """Test successful login via browser OAuth2 flow."""
-        import re
-
-        # Mock the login page (GET follows redirects to CIAM login page)
-        mocked.get(
-            re.compile(r"https://cookidoo\.ch/profile/de-CH/login.*"),
-            status=HTTPStatus.OK,
-            body=COOKIDOO_TEST_LOGIN_PAGE_HTML,
-        )
-
-        # Mock the CIAM login POST (returns redirect with auth cookies)
-        mocked.post(
-            "https://ciam.prod.cookidoo.vorwerk-digital.com/login-srv/login",
-            status=HTTPStatus.OK,
-        )
-
-        # Manually set cookies since aioresponses doesn't handle Set-Cookie
-        cookidoo._session.cookie_jar.update_cookies(
-            {"_oauth2_proxy": "test-proxy-value", "v-authenticated": "test-auth-value"}
-        )
+        """Test a successful OAuth2 login."""
+        self._mock_login_flow(mocked)
 
         await cookidoo.login()
+
         assert cookidoo._logged_in
+        assert cookidoo.auth_data is not None
+        assert cookidoo.auth_data.access_token == "test-access-token"
+        assert cookidoo.auth_data.refresh_token == "test-refresh-token"
+        assert cookidoo._api_headers["Authorization"] == "Bearer test-access-token"
+
+    async def test_token_request_is_a_public_client_request(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """The code exchange identifies the client without authenticating it.
+
+        CIAM accepts the exchange on the strength of the PKCE ``code_verifier``,
+        so no client secret is sent (and none is configurable).
+        """
+        self._mock_login_flow(mocked)
+
+        await cookidoo.login()
+
+        (_, kwargs) = mocked.requests[("POST", URL(TOKEN_ENDPOINT))][0]
+        assert kwargs["data"]["client_id"] == TEST_CLIENT_ID
+        assert kwargs["data"]["code_verifier"]
+        assert "client_secret" not in kwargs["data"]
+        assert "Authorization" not in kwargs["headers"]
+
+    async def test_refresh_is_a_public_client_request(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """The refresh grant identifies the client the same way."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_TOKEN_RESPONSE)
+        cookidoo.apply_auth_data(CookidooAuthData("old", "test-refresh-token", 0.0))
+
+        await cookidoo.refresh()
+
+        (_, kwargs) = mocked.requests[("POST", URL(TOKEN_ENDPOINT))][0]
+        assert kwargs["data"]["client_id"] == TEST_CLIENT_ID
+        assert "client_secret" not in kwargs["data"]
+        assert "Authorization" not in kwargs["headers"]
 
     async def test_login_page_unreachable(
         self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:
-        """Test login when login page returns error."""
-        import re
-
-        mocked.get(
-            re.compile(r"https://cookidoo\.ch/profile/de-CH/login.*"),
-            status=HTTPStatus.SERVICE_UNAVAILABLE,
-        )
+        """Test login when the authorize/login page returns an error."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, status=HTTPStatus.SERVICE_UNAVAILABLE)
 
         with pytest.raises(CookidooAuthException, match="could not reach login page"):
             await cookidoo.login()
@@ -150,10 +204,9 @@ class TestLogin:
         self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:
         """Test login when requestId cannot be extracted."""
-        import re
-
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
         mocked.get(
-            re.compile(r"https://cookidoo\.ch/profile/de-CH/login.*"),
+            AUTHZ_RE,
             status=HTTPStatus.OK,
             body="<html><body>No form here</body></html>",
         )
@@ -164,23 +217,173 @@ class TestLogin:
     async def test_login_invalid_credentials(
         self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:
-        """Test login with invalid credentials (no auth cookies set)."""
-        import re
+        """Invalid credentials yield no authorization code."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        # The login service replies 200 (re-renders the form) instead of redirecting.
+        mocked.post(CIAM_LOGIN_SRV_URL, status=HTTPStatus.OK)
 
-        mocked.get(
-            re.compile(r"https://cookidoo\.ch/profile/de-CH/login.*"),
-            status=HTTPStatus.OK,
-            body=COOKIDOO_TEST_LOGIN_PAGE_HTML,
+        with pytest.raises(CookidooAuthException, match="invalid credentials"):
+            await cookidoo.login()
+
+    async def test_login_follows_intermediate_redirects(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Redirects before the app scheme are followed to capture the code."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        interstitial = (
+            "https://ciam.prod.cookidoo.vorwerk-digital.com/login-srv/continue"
         )
         mocked.post(
-            "https://ciam.prod.cookidoo.vorwerk-digital.com/login-srv/login",
-            status=HTTPStatus.OK,
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": interstitial},
+        )
+        mocked.get(
+            interstitial,
+            status=HTTPStatus.FOUND,
+            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
+        )
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_TOKEN_RESPONSE)
+
+        await cookidoo.login()
+
+        assert cookidoo._logged_in
+
+    async def test_login_state_mismatch(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A state that does not match the one sent aborts the login."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        mocked.post(
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code&state=tampered"},
         )
 
-        with pytest.raises(
-            CookidooAuthException, match="authentication cookies were not set"
-        ):
+        with pytest.raises(CookidooAuthException, match="state mismatch"):
             await cookidoo.login()
+
+    async def test_login_redirect_loop(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """An endless redirect chain gives up instead of looping forever."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        loop_url = "https://ciam.prod.cookidoo.vorwerk-digital.com/login-srv/loop"
+        mocked.post(
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": loop_url},
+        )
+        mocked.get(
+            re.compile(r".*/login-srv/loop.*"),
+            status=HTTPStatus.FOUND,
+            headers={"Location": loop_url},
+            repeat=True,
+        )
+
+        with pytest.raises(CookidooAuthException, match="invalid credentials"):
+            await cookidoo.login()
+
+    async def test_login_token_exchange_failure(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A rejected code exchange surfaces as an auth exception."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        mocked.post(
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
+        )
+        mocked.post(TOKEN_ENDPOINT, status=HTTPStatus.BAD_REQUEST)
+
+        with pytest.raises(CookidooAuthException, match="Token exchange failed"):
+            await cookidoo.login()
+
+    async def test_login_unexpected_token_response(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A token response without an access token surfaces as an auth exception."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        mocked.post(
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
+        )
+        mocked.post(TOKEN_ENDPOINT, payload={"token_type": "Bearer"})
+
+        with pytest.raises(CookidooAuthException, match="Unexpected token response"):
+            await cookidoo.login()
+
+    async def test_discovery_is_cached(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """The OIDC discovery document is only fetched once."""
+        self._mock_login_flow(mocked)
+
+        await cookidoo.login()
+        # A second login must not hit the discovery endpoint again, it is only
+        # mocked once and a second request would fail.
+        mocked.get(AUTHZ_RE, status=HTTPStatus.OK, body=COOKIDOO_TEST_LOGIN_PAGE_HTML)
+        mocked.post(
+            CIAM_LOGIN_SRV_URL,
+            status=HTTPStatus.FOUND,
+            headers={"Location": f"{TEST_REDIRECT_URI}?code=test-code"},
+        )
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_TOKEN_RESPONSE)
+
+        await cookidoo.login()
+
+        assert cookidoo._logged_in
+
+    def test_default_oauth_client_is_the_public_mobile_client(self) -> None:
+        """The client identifiers default to the app's public ones."""
+        cfg = CookidooConfig()
+
+        assert cfg.client_id == OAUTH_CLIENT_ID
+        assert cfg.redirect_uri == OAUTH_REDIRECT_URI
+        assert not hasattr(cfg, "client_secret")
+
+    @pytest.mark.parametrize(
+        ("client_id", "redirect_uri", "expected"),
+        [
+            ("", TEST_REDIRECT_URI, "client_id"),
+            (TEST_CLIENT_ID, "", "redirect_uri"),
+            ("", "", "client_id, redirect_uri"),
+        ],
+    )
+    async def test_login_with_blanked_client_config(
+        self,
+        session: ClientSession,
+        client_id: str,
+        redirect_uri: str,
+        expected: str,
+    ) -> None:
+        """Overriding an identifier with an empty value is rejected early."""
+        cookidoo = Cookidoo(
+            session,
+            cfg=CookidooConfig(client_id=client_id, redirect_uri=redirect_uri),
+        )
+
+        with pytest.raises(CookidooConfigException, match=expected):
+            await cookidoo.login()
+
+    async def test_refresh_with_blanked_client_config(
+        self, session: ClientSession
+    ) -> None:
+        """Refreshing a restored token validates the client config too."""
+        cookidoo = Cookidoo(session, cfg=CookidooConfig(client_id=""))
+        cookidoo.apply_auth_data(CookidooAuthData("old", "ref", 9999999999.0))
+
+        with pytest.raises(
+            CookidooConfigException, match="Missing OAuth2 client configuration"
+        ):
+            await cookidoo.refresh()
 
     @pytest.mark.parametrize(
         "exception",
@@ -192,134 +395,118 @@ class TestLogin:
     async def test_request_exceptions(
         self, mocked: aioresponses, cookidoo: Cookidoo, exception: Exception
     ) -> None:
-        """Test exceptions."""
-        import re
+        """Test that transport exceptions surface as request exceptions."""
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.get(AUTHZ_RE, exception=exception)
 
-        mocked.get(
-            re.compile(r"https://cookidoo\.ch/profile/de-CH/login.*"),
-            exception=exception,
-        )
         with pytest.raises(CookidooRequestException):
             await cookidoo.login()
 
 
-class TestCookiePersistence:
-    """Tests for cookie save/load methods."""
+class TestTokenPersistenceAndRefresh:
+    """Tests for token persistence and refresh."""
 
-    async def test_save_and_load_cookies(
-        self, cookidoo: Cookidoo, tmp_path: object
+    async def test_save_and_load_token(
+        self, cookidoo: Cookidoo, tmp_path: pathlib.Path
     ) -> None:
-        """Test saving and loading cookies."""
-        import pathlib
+        """Test saving and restoring tokens across instances."""
+        cookidoo.apply_auth_data(CookidooAuthData("acc", "ref", 9999999999.0))
+        token_file = tmp_path / "token.json"
+        cookidoo.save_token(token_file)
+        assert token_file.exists()
 
-        cookie_file = pathlib.Path(str(tmp_path)) / "cookies.json"
+        fresh = Cookidoo(cookidoo._session)
+        fresh.load_token(token_file)
+        assert fresh._logged_in
+        assert fresh.auth_data is not None
+        assert fresh.auth_data.access_token == "acc"
+        assert fresh.auth_data.refresh_token == "ref"
 
-        # Set some cookies on the session
-        cookidoo._session.cookie_jar.update_cookies(
-            {"_oauth2_proxy": "proxy-val", "v-authenticated": "auth-val"}
-        )
-
-        # Save
-        cookidoo.save_cookies(cookie_file)
-        assert cookie_file.exists()
-
-        # Load into a fresh Cookidoo instance on same session
-        # (clear cookies first)
-        cookidoo._session.cookie_jar.clear()
-        assert not cookidoo._logged_in or True  # reset
-        cookidoo._logged_in = False
-
-        cookidoo.load_cookies(cookie_file)
-        assert cookidoo._logged_in
-
-        cookie_names = {c.key for c in cookidoo._session.cookie_jar}
-        assert "_oauth2_proxy" in cookie_names
-        assert "v-authenticated" in cookie_names
-
-    async def test_load_cookies_missing_file(self, cookidoo: Cookidoo) -> None:
-        """Test loading cookies from nonexistent file."""
-        from cookidoo_api.exceptions import CookidooConfigException
-
-        with pytest.raises(CookidooConfigException, match="Cannot load cookies"):
-            cookidoo.load_cookies("/nonexistent/path/cookies.json")
-
-    async def test_load_cookies_without_auth_cookies(
-        self, cookidoo: Cookidoo, tmp_path: object
+    async def test_save_token_not_logged_in(
+        self, cookidoo: Cookidoo, tmp_path: pathlib.Path
     ) -> None:
-        """Test that loading cookies without required auth cookies does not set logged_in."""
-        import json
-        import pathlib
+        """Saving without a login raises."""
+        with pytest.raises(CookidooConfigException, match="not logged in"):
+            cookidoo.save_token(tmp_path / "token.json")
 
-        cookie_file = pathlib.Path(str(tmp_path)) / "cookies.json"
-        cookie_file.write_text(
-            json.dumps(
-                [{"key": "some_other", "value": "val", "domain": "", "path": "/"}]
-            )
-        )
-        cookidoo._logged_in = False
-        cookidoo.load_cookies(cookie_file)
-        assert not cookidoo._logged_in
+    async def test_load_token_missing_file(self, cookidoo: Cookidoo) -> None:
+        """Loading a missing token file raises."""
+        with pytest.raises(CookidooConfigException, match="Cannot load token"):
+            cookidoo.load_token("/nonexistent/path/token.json")
 
-    async def test_corrupted_cookies_recovery(
-        self, mocked: aioresponses, cookidoo: Cookidoo, tmp_path: object
+    async def test_refresh(self, mocked: aioresponses, cookidoo: Cookidoo) -> None:
+        """Test refreshing the access token."""
+        cookidoo.apply_auth_data(CookidooAuthData("old", "ref", 9999999999.0))
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE)
+
+        await cookidoo.refresh()
+
+        assert cookidoo.auth_data is not None
+        assert cookidoo.auth_data.access_token == "refreshed-access-token"
+        assert cookidoo.auth_data.refresh_token == "refreshed-refresh-token"
+
+    async def test_refresh_without_login(self, cookidoo: Cookidoo) -> None:
+        """Refreshing without a login raises."""
+        with pytest.raises(CookidooAuthException, match="not logged in"):
+            await cookidoo.refresh()
+
+    async def test_refresh_rejected(
+        self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:
-        """Test recovery flow: load expired/corrupted cookies, API fails, re-login succeeds."""
-        import pathlib
-        import re
+        """A rejected refresh surfaces as an auth exception."""
+        cookidoo.apply_auth_data(CookidooAuthData("old", "ref", 9999999999.0))
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, status=HTTPStatus.UNAUTHORIZED)
 
-        cookie_file = pathlib.Path(str(tmp_path)) / "cookies.json"
+        with pytest.raises(CookidooAuthException, match="Token refresh failed"):
+            await cookidoo.refresh()
 
-        # Set corrupted/expired auth cookies
-        cookidoo._session.cookie_jar.update_cookies(
-            {"_oauth2_proxy": "corrupted-value", "v-authenticated": "expired"}
-        )
-        cookidoo.save_cookies(cookie_file)
+    async def test_refresh_request_exception(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A transport error during refresh surfaces as a request exception."""
+        cookidoo.apply_auth_data(CookidooAuthData("old", "ref", 9999999999.0))
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, exception=ClientError())
 
-        # Clear and reload the corrupted cookies
-        cookidoo._session.cookie_jar.clear()
-        cookidoo._logged_in = False
-        cookidoo.load_cookies(cookie_file)
-        assert cookidoo._logged_in  # Cookies are present, so flag is set
+        with pytest.raises(CookidooRequestException, match="Token refresh failed"):
+            await cookidoo.refresh()
 
-        # API call fails with 401 because cookies are invalid
-        mocked.get(
-            "https://cookidoo.ch/community/profile",
-            status=HTTPStatus.UNAUTHORIZED,
-            payload={"error": "Unauthorized", "error_description": "Token expired"},
-        )
-        with pytest.raises(CookidooAuthException):
-            await cookidoo.get_user_info()
-
-        # Recovery: re-login
-        mocked.get(
-            re.compile(r"https://cookidoo\.ch/profile/de-CH/login.*"),
-            status=HTTPStatus.OK,
-            body=COOKIDOO_TEST_LOGIN_PAGE_HTML,
-        )
-        mocked.post(
-            "https://ciam.prod.cookidoo.vorwerk-digital.com/login-srv/login",
-            status=HTTPStatus.OK,
-        )
-        cookidoo._session.cookie_jar.update_cookies(
-            {
-                "_oauth2_proxy": "fresh-proxy-value",
-                "v-authenticated": "fresh-auth-value",
-            }
-        )
-        await cookidoo.login()
-        assert cookidoo._logged_in
-
-        # API call now succeeds
+    async def test_no_refresh_on_valid_token(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A still valid access token is used as is, without a refresh."""
+        cookidoo.apply_auth_data(CookidooAuthData("valid", "ref", 9999999999.0))
         mocked.get(
             "https://cookidoo.ch/community/profile",
             payload=COOKIDOO_TEST_RESPONSE_USER_INFO,
             status=HTTPStatus.OK,
         )
-        data = await cookidoo.get_user_info()
-        assert data.username == COOKIDOO_TEST_RESPONSE_USER_INFO["userInfo"]["username"]  # type: ignore[index]
 
-        # Save fresh cookies for next run
-        cookidoo.save_cookies(cookie_file)
+        await cookidoo.get_user_info()
+
+        # No token endpoint was mocked, so a refresh would have failed.
+        assert cookidoo.auth_data is not None
+        assert cookidoo.auth_data.access_token == "valid"
+
+    async def test_auto_refresh_on_expired_token(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """An expired access token is refreshed automatically before a request."""
+        cookidoo.apply_auth_data(CookidooAuthData("expired", "ref", 0.0))
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE)
+        mocked.get(
+            "https://cookidoo.ch/community/profile",
+            payload=COOKIDOO_TEST_RESPONSE_USER_INFO,
+            status=HTTPStatus.OK,
+        )
+
+        await cookidoo.get_user_info()
+
+        assert cookidoo.auth_data is not None
+        assert cookidoo.auth_data.access_token == "refreshed-access-token"
 
 
 class TestGetUserInfo:


### PR DESCRIPTION
Supersedes #250, #252 and, if you want it, the fallback design in #253.

The premise those PRs were built on turns out to be wrong. **The token exchange never authenticates the client** — CIAM accepts it on the strength of the PKCE `code_verifier` and does not check a client secret at all. So there is no secret to ship, to withhold, or to make anyone extract from an APK, and OAuth2 works out of the box with nothing but an email and a password.

## The evidence

Probed against the production token endpoint, exchanging one real authorization code:

| token request | result |
| --- | --- |
| `client_id` + `code_verifier`, no secret | **200 — token** |
| `client_id` + `code_verifier` + **wrong** secret | **200 — token** |
| `client_id` + `code_verifier` + correct secret | 200 — token |
| `client_id`, **no** `code_verifier`, no secret | 400 `invalid_client` |
| `code_verifier`, no `client_id` | 400 `invalid_client` |

The third row is the decisive one: a deliberately wrong secret is accepted, so the secret is not part of what the server verifies. PKCE is what binds the exchange to the client instance that began the flow — which is what PKCE is for, and the shape [RFC 8252 §8.5](https://datatracker.ietf.org/doc/html/rfc8252#section-8.5) prescribes for native apps, whose "secrets" cannot stay secret in a distributed binary anyway.

## What ships in the repo, and why it is not a secret

- `client_id` = `mobile-android` — a client id is a public identifier by definition. [RFC 6749 §2.2](https://datatracker.ietf.org/doc/html/rfc6749#section-2.2): *"The client identifier is not a secret; it is exposed to the resource owner and MUST NOT be used alone for client authentication."*
- `redirect_uri` = `com.vorwerk.cookidoo://code-grant` — the app's URL scheme. It travels in the query string of every authorize request and is declared in the app manifest.

Both are plain config fields, overridable if the app's registration ever changes. Nothing secret is committed.

## Why this removes the cookie session rather than falling back to it

The fallback in #253 exists to spare users who cannot supply client credentials. With zero-config OAuth2 there is no such user, so the fallback would only add a second auth path to maintain — and it is the weaker one:

- `iot-api.production-eu.cookidoo.vorwerk-digital.com/devices` answers **401** to a cookie session and **200** to this bearer token, so remote monitoring is reachable only this way.
- Keeping both means every request path, the persistence helpers and `auth_data` have to stay correct under two auth modes. That seam is already where the bugs in #256 came from.

If you would still rather keep it, say so and I will re-add it on top — it is additive to this branch.

## Changes

- OAuth2 authorization-code + PKCE login against CIAM (email/password, no browser)
- `refresh()` plus automatic refresh of an expiring access token before each request
- `CookidooAuthData` (exported) + `auth_data` property / `apply_auth_data()`
- **BREAKING:** `save_cookies`/`load_cookies` → `save_token`/`load_token`
- `client_id` / `redirect_uri` on `CookidooConfig`, defaulted and overridable
- Tests pin the wire format — client id in the body, no `client_secret`, no `Authorization` header — for both the code exchange and the refresh grant
- `docs/oauth-client.md` rewritten around *why there is no secret to obtain*
- README, `example.py`, `.env.example` and the smoke-test workflows drop the `CLIENT_ID` / `CLIENT_SECRET` / `REDIRECT_URI` inputs, so the workflows no longer need those repository secrets

`CookieJar(unsafe=True)` is still required — the login redirect chain relies on cookies even though the session no longer authenticates with them.

## Verification

- `pytest` 295 passed, `mypy` clean, `ruff check` clean. `ruff format` flags `cookidoo_api/helpers.py` — pre-existing on master (ruff version drift), untouched here.
- Verified live against a real account with **email and password only**: `login()` → `get_user_info()` / `get_devices()` / `get_active_subscription()` / `get_additional_items()` → `refresh()` → `save_token()` and `load_token()` in a fresh session.
- The resulting token is indistinguishable from a secret-authenticated one — same `aud`, scopes and roles — and reaches `iot-api` (`200` where an unauthenticated or garbage-bearer request gets `401`).

## Knock-on effects

- #252 (APK extraction script) is obsolete — closing it.
- #250 is replaced by this branch — closing it.
- #251 (remote monitoring) is rebased onto this branch.
- #256 fixes the two-flow seam in #253; if you take this PR instead, commits 1 and 2 of #256 become moot and only the smoke-test workflow fix still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfmRF6TkekKVToVEssvnQt
