### PR TITLE
Allow aiohttp 3.14 (unbreak Home Assistant)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ authors = [
   { name = "Cyrill Raccaud", email = "cyrill.raccaud+pypi@gmail.com" },
 ]
 dependencies = [
-  "aiohttp~=3.13.0",
-  "aiofiles~=25.1.0",
+  "aiohttp~=3.13",
+  "aiofiles~=25.1",
   "isodate~=0.7.2",
 ]
 requires-python = ">=3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp~=3.13.0
-aiofiles~=25.1.0
+aiohttp~=3.13
+aiofiles~=25.1
 isodate~=0.7.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
-aiohttp~=3.13.0
-aiofiles~=25.1.0
+aiohttp~=3.13
+aiofiles~=25.1
 mypy>=2.3.1
 pydantic>=2.13.4
 pre-commit>=4.6.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,7 @@ pytest-cov>=7.1.0
 pytest>=9.1.1
 python-dotenv>=1.2.3
 aioresponses>=0.7.9
+# aioresponses 0.7.9 does not support aiohttp 3.14 yet (it constructs
+# ClientResponse without the new required stream_writer argument), so the
+# test environment stays on 3.13. The runtime dependency allows 3.14.
+aiohttp<3.14


### PR DESCRIPTION
## What

- `pyproject.toml` / `requirements.txt`: `aiohttp~=3.13.0` → `~=3.13`, `aiofiles~=25.1.0` → `~=25.1`
- `requirements_test.txt`: pin the **test environment** to `aiohttp<3.14` (see below)
- `isodate~=0.7.2` left as-is — for a 0.x package that is the right guard.

## Why

`~=3.13.0` is the patch-level compatible-release operator, so it resolves to `>=3.13.0,<3.14`. Home Assistant Core pins `aiohttp==3.14.3`, which makes `cookidoo-api==0.18.0` impossible to install there:

```console
$ pip install --dry-run cookidoo-api==0.18.0 -c homeassistant/package_constraints.txt
ERROR: Cannot install cookidoo-api==0.18.0 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

That blocks the HA bump to 0.18.0 (and with it the OAuth2 switch). `0.17.2` had unpinned deps, so this is a regression from #217 rather than an intentional cap on 3.14.

`~=3.13` keeps the intent of #217 — no silent jump to aiohttp 4 — while allowing 3.14.

## The test-environment pin

aioresponses 0.7.9 (latest) doesn't support aiohttp 3.14: it constructs `ClientResponse` without the now-required keyword-only `stream_writer` argument.

```
TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
```

On aiohttp 3.14.3 that accounts for **all** 206 failures (412 occurrences of the identical `TypeError`); the remaining 151 tests pass. Nothing in `cookidoo_api` itself is implicated, so `requirements_test.txt` keeps the test env on 3.13 until aioresponses catches up, rather than capping the runtime dependency.

## Verified

- `mypy cookidoo_api` on aiohttp 3.14.3 → `Success: no issues found in 8 source files`
- `pytest tests` on aiohttp 3.13.5 → `357 passed` (unchanged)
- `pip install --dry-run` against HA's `package_constraints.txt` resolves with this change applied

## Follow-up

A 0.18.1 release would let me send the Home Assistant PR that bumps to it and adopts the new OAuth2 token persistence.