### PR TITLE
feat: receive remote-monitoring cook state over FCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ Your account credentials are all that is needed. The library logs in as a *publi
 
 Run the [example script](https://github.com/miaucl/cookidoo-api/blob/master/example.py) and have a look at the inline comments for more explanation.
 
+## Remote Monitoring
+
+Appliance cook state is not something you can fetch: the appliance pushes it to
+the Cookidoo mobile app as a Firebase Cloud Messaging data message, and there is
+no endpoint that returns it. `CookidooRemoteMonitoring` registers a push token of
+its own with the remote-monitoring backend and decodes the messages that follow.
+
+```python
+monitoring = CookidooRemoteMonitoring(
+    cookidoo,
+    lambda activity: print(activity.state, activity.recipe_name),
+    mobile_app_id="a-stable-per-installation-uuid",
+    credentials=stored_credentials,          # optional, keeps the same push token
+    on_credentials=save_credentials,         # optional, called when they rotate
+)
+await monitoring.start()
+...
+await monitoring.stop()
+```
+
+Persisting the FCM credentials is worthwhile: reusing them keeps the same push
+token across restarts instead of leaving a new one registered every time.
+
 ## Exceptions
 
 In case something goes wrong during a request, several [exceptions](https://github.com/miaucl/cookidoo/blob/master/cookidoo_api/exceptions.py) can be thrown, all inheriting from `CookidooException`.

--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -18,6 +18,7 @@ from .helpers import (
     get_language_options,
     get_localization_options,
 )
+from .remote_monitoring import CookidooRemoteMonitoring
 from .types import (
     CookidooAdditionalItem,
     CookidooAuthData,
@@ -45,6 +46,7 @@ from .types import (
 
 __all__ = [
     "Cookidoo",
+    "CookidooRemoteMonitoring",
     "get_country_options",
     "get_language_options",
     "get_localization_options",

--- a/cookidoo_api/const.py
+++ b/cookidoo_api/const.py
@@ -98,6 +98,18 @@ RMI_DEVICES: Final = "rmi:devices"
 PUSH_BUNDLE_ID: Final = "com.vorwerk.cookidoo"
 PUSH_PLATFORM: Final = "AN"  # Android; the value the app sends
 
+# Firebase project of the Cookidoo Android app. Appliance state is delivered as
+# an FCM data message, so a client that wants to observe it has to register with
+# this project. These are the app's public client identifiers, not credentials.
+FCM_PROJECT_ID: Final = "cookidoo-app"
+FCM_APP_ID: Final = "1:447648593759:android:ebfbf2b01378844b"
+FCM_API_KEY: Final = "AIzaSyCPyZm8EAdpVhWhNLFv3cOw_Kx4iNxR_E4"
+FCM_SENDER_ID: Final = "447648593759"
+
+# The appliance flattens the cook state into the data message, but the app's push
+# service also reads it from one of these keys.
+PUSH_NESTED_PAYLOAD_KEYS: Final = ("cookingActivity", "remoteMonitoringInfo")
+
 CUSTOM_COLLECTIONS_PATH: Final = "organize/{language}/api/custom-list"
 CUSTOM_COLLECTIONS_PATH_ACCEPT: Final = (
     "application/vnd.vorwerk.organize.custom-list.mobile+json"

--- a/cookidoo_api/remote_monitoring.py
+++ b/cookidoo_api/remote_monitoring.py
@@ -1,0 +1,231 @@
+"""Live appliance cook state over Firebase Cloud Messaging.
+
+The remote-monitoring backend has no endpoint that returns the current cook
+state: an appliance pushes its state to the Cookidoo mobile app as a Firebase
+Cloud Messaging *data message*. To observe it, a client has to register a push
+token of its own (:meth:`Cookidoo.register_push_token`) and then receive those
+messages.
+
+:class:`CookidooRemoteMonitoring` does both. It obtains an FCM registration
+token without an Android device (via ``firebase-messaging``), registers it,
+and decodes every incoming message with
+:func:`cookidoo_api.cooking_activity_from_push` before handing it to a callback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import json
+import logging
+from typing import Any
+
+from aiohttp import ClientSession
+from firebase_messaging import FcmPushClient, FcmRegisterConfig
+
+from cookidoo_api.const import (
+    FCM_API_KEY,
+    FCM_APP_ID,
+    FCM_PROJECT_ID,
+    FCM_SENDER_ID,
+    PUSH_NESTED_PAYLOAD_KEYS,
+)
+from cookidoo_api.cookidoo import Cookidoo
+from cookidoo_api.helpers import cooking_activity_from_push
+from cookidoo_api.types import CookidooCookingActivity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def cook_state_payload(message: Any) -> dict[str, Any] | None:
+    """Extract the cook-state mapping from a Firebase data message.
+
+    The appliance flattens the cook fields into the data map, but the app's push
+    service also accepts them nested under ``cookingActivity`` /
+    ``remoteMonitoringInfo`` (as an object or as a JSON string), so all three
+    shapes are accepted here.
+
+    Returns
+    -------
+    dict[str, Any] | None
+        The cook-state mapping, or ``None`` if the message carries none.
+
+    """
+    if not isinstance(message, dict):
+        return None
+    data = message.get("data", message)
+    if not isinstance(data, dict):
+        return None
+    if "deviceId" in data:
+        return data
+    return _nested_cook_state(data)
+
+
+def _nested_cook_state(data: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the cook state nested under one of the known payload keys."""
+    for key in PUSH_NESTED_PAYLOAD_KEYS:
+        value = data.get(key)
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            try:
+                return dict(json.loads(value))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                _LOGGER.debug("Could not decode the %s push payload", key)
+                return None
+    return None
+
+
+def token_from_credentials(credentials: Any) -> str | None:
+    """Return the FCM registration token held by a credentials mapping.
+
+    Returns
+    -------
+    str | None
+        The token, or ``None`` if the mapping does not carry one.
+
+    """
+    try:
+        token = credentials["fcm"]["registration"]["token"]
+    except (KeyError, TypeError):
+        return None
+    return token if isinstance(token, str) else None
+
+
+class CookidooRemoteMonitoring:
+    """Receives live cook state for the appliances of an account.
+
+    The FCM credentials are worth persisting: reusing them keeps the same push
+    token across restarts instead of leaving a new one registered every time.
+    Pass them back in via ``credentials`` and keep them fresh with
+    ``on_credentials``.
+    """
+
+    def __init__(
+        self,
+        cookidoo: Cookidoo,
+        on_cooking_activity: Callable[[CookidooCookingActivity], None],
+        *,
+        mobile_app_id: str,
+        session: ClientSession | None = None,
+        credentials: dict[str, Any] | None = None,
+        on_credentials: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        """Init the remote monitoring receiver.
+
+        Parameters
+        ----------
+        cookidoo
+            A logged-in client, used to register and unregister the push token.
+        on_cooking_activity
+            Called with every decoded cook-state update. Invoked from the event
+            loop the receiver runs on.
+        mobile_app_id
+            A stable per-installation identifier for this client.
+        session
+            Client session for the Firebase requests. A private one is created
+            when omitted.
+        credentials
+            FCM credentials from a previous run, to reuse its push token.
+        on_credentials
+            Called whenever the FCM credentials change, for persistence.
+
+        """
+        self._cookidoo = cookidoo
+        self._on_cooking_activity = on_cooking_activity
+        self._mobile_app_id = mobile_app_id
+        self._session = session
+        self._credentials = credentials
+        self._on_credentials = on_credentials
+        self._client: FcmPushClient | None = None
+        self._token: str | None = None
+        self._registered_token: str | None = None
+        self._reregister_task: asyncio.Task[None] | None = None
+
+    @property
+    def credentials(self) -> dict[str, Any] | None:
+        """The current FCM credentials, for persistence."""
+        return self._credentials
+
+    @property
+    def token(self) -> str | None:
+        """The current FCM registration token. ``None`` until started."""
+        return self._token
+
+    async def start(self) -> None:
+        """Start listening and register for cook-state pushes.
+
+        Raises
+        ------
+        CookidooAuthException
+            When the access token is not valid anymore
+        CookidooRequestException
+            If registering the push token fails.
+        CookidooParseException
+            If the remote-monitoring endpoints cannot be resolved.
+
+        """
+        self._client = FcmPushClient(
+            self._handle_message,
+            FcmRegisterConfig(
+                project_id=FCM_PROJECT_ID,
+                app_id=FCM_APP_ID,
+                api_key=FCM_API_KEY,
+                messaging_sender_id=FCM_SENDER_ID,
+            ),
+            self._credentials,
+            self._handle_credentials,
+            http_client_session=self._session,
+        )
+        self._token = await self._client.checkin_or_register()
+        await self._client.start()
+        await self._register(self._token)
+
+    async def stop(self) -> None:
+        """Stop listening and drop the push token registration."""
+        if self._reregister_task is not None:
+            self._reregister_task.cancel()
+            self._reregister_task = None
+        if self._registered_token is not None:
+            try:
+                await self._cookidoo.unregister_push_token(self._registered_token)
+            except Exception:
+                _LOGGER.debug("Unregistering the push token failed", exc_info=True)
+            self._registered_token = None
+        if self._client is not None:
+            await self._client.stop()
+            self._client = None
+
+    async def _register(self, token: str) -> None:
+        """Subscribe ``token`` to this account's appliance state."""
+        await self._cookidoo.register_push_token(token, self._mobile_app_id)
+        self._registered_token = token
+
+    def _handle_message(
+        self, message: dict[str, Any], persistent_id: str, context: Any = None
+    ) -> None:
+        """Decode a push message and report the cook state it carries."""
+        payload = cook_state_payload(message)
+        if payload is None:
+            _LOGGER.debug("Ignoring a push without cook state: %s", sorted(message))
+            return
+        self._on_cooking_activity(cooking_activity_from_push(payload))
+
+    def _handle_credentials(self, credentials: dict[str, Any]) -> None:
+        """Persist rotated FCM credentials and re-register a rotated token."""
+        self._credentials = credentials
+        if self._on_credentials is not None:
+            self._on_credentials(credentials)
+        # A rotated token receives nothing until it is registered in its turn.
+        token = token_from_credentials(credentials)
+        if token is not None and token != self._registered_token:
+            self._token = token
+            self._reregister_task = asyncio.create_task(self._async_reregister(token))
+
+    async def _async_reregister(self, token: str) -> None:
+        """Re-register after a token rotation, without killing the receiver."""
+        try:
+            await self._register(token)
+        except Exception:
+            _LOGGER.warning("Re-registering the rotated push token failed")
+            _LOGGER.debug("Re-registration traceback", exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 dependencies = [
   "aiohttp~=3.13",
+  "firebase-messaging~=0.4",
   "aiofiles~=25.1",
   "isodate~=0.7.2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp~=3.13
+firebase-messaging~=0.4
 aiofiles~=25.1
 isodate~=0.7.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 aiohttp~=3.13
+firebase-messaging~=0.4
 aiofiles~=25.1
 mypy>=2.3.1
 pydantic>=2.13.4

--- a/tests/test_remote_monitoring.py
+++ b/tests/test_remote_monitoring.py
@@ -1,0 +1,290 @@
+"""Unit tests for the remote-monitoring push receiver."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cookidoo_api.cookidoo import Cookidoo
+from cookidoo_api.remote_monitoring import (
+    CookidooRemoteMonitoring,
+    cook_state_payload,
+    token_from_credentials,
+)
+from cookidoo_api.types import CookidooCookingActivity, CookidooCookState
+
+from .responses import COOKIDOO_TEST_PUSH_COOKING_ACTIVITY
+
+MOBILE_APP_ID = "c4805c69-0000-0000-0000-000000000000"
+TOKEN = "fcm-token"
+ROTATED_TOKEN = "fcm-token-rotated"
+
+
+def credentials(token: str) -> dict[str, Any]:
+    """Build an FCM credentials mapping carrying ``token``."""
+    return {"fcm": {"registration": {"token": token}}}
+
+
+@pytest.fixture(name="push_client")
+def mock_push_client() -> Any:
+    """Patch FcmPushClient with a mock that reports a registration token."""
+    with patch(
+        "cookidoo_api.remote_monitoring.FcmPushClient", autospec=True
+    ) as mock_client:
+        client = mock_client.return_value
+        client.checkin_or_register.return_value = TOKEN
+        yield mock_client
+
+
+class TestCookStatePayload:
+    """Tests for extracting the cook state out of a push message."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            pytest.param(COOKIDOO_TEST_PUSH_COOKING_ACTIVITY, id="flattened"),
+            pytest.param(
+                {"data": COOKIDOO_TEST_PUSH_COOKING_ACTIVITY}, id="under-data"
+            ),
+            pytest.param(
+                {"data": {"cookingActivity": COOKIDOO_TEST_PUSH_COOKING_ACTIVITY}},
+                id="nested-object",
+            ),
+            pytest.param(
+                {
+                    "data": {
+                        "remoteMonitoringInfo": json.dumps(
+                            COOKIDOO_TEST_PUSH_COOKING_ACTIVITY
+                        )
+                    }
+                },
+                id="nested-json-string",
+            ),
+        ],
+    )
+    def test_accepted_shapes(self, message: Any) -> None:
+        """Every shape the app's push service accepts yields the cook state."""
+        assert cook_state_payload(message) == COOKIDOO_TEST_PUSH_COOKING_ACTIVITY
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            pytest.param("not-a-mapping", id="not-a-dict"),
+            pytest.param({"data": "not-a-mapping"}, id="data-not-a-dict"),
+            pytest.param({"data": {"unrelated": "message"}}, id="no-cook-state"),
+            pytest.param(
+                {"data": {"cookingActivity": "{not json"}}, id="undecodable-json"
+            ),
+        ],
+    )
+    def test_rejected_shapes(self, message: Any) -> None:
+        """A message without a usable cook state yields ``None``."""
+        assert cook_state_payload(message) is None
+
+
+@pytest.mark.parametrize(
+    ("creds", "expected"),
+    [
+        pytest.param(credentials(TOKEN), TOKEN, id="present"),
+        pytest.param({"fcm": {}}, None, id="incomplete"),
+        pytest.param({"fcm": {"registration": {"token": 42}}}, None, id="not-a-string"),
+        pytest.param(None, None, id="missing"),
+    ],
+)
+def test_token_from_credentials(creds: Any, expected: str | None) -> None:
+    """The registration token is read defensively out of the credentials."""
+    assert token_from_credentials(creds) == expected
+
+
+class TestRemoteMonitoring:
+    """Tests for the receiver lifecycle."""
+
+    async def test_start_registers_the_token(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """Starting checks in with Firebase and subscribes the token."""
+        cookidoo.register_push_token = AsyncMock()  # type: ignore[method-assign]
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo, MagicMock(), mobile_app_id=MOBILE_APP_ID
+        )
+
+        await monitoring.start()
+
+        assert monitoring.token == TOKEN
+        push_client.return_value.start.assert_awaited_once()
+        cookidoo.register_push_token.assert_awaited_once_with(TOKEN, MOBILE_APP_ID)
+
+    async def test_stop_unregisters_the_token(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """Stopping drops the subscription and the client."""
+        cookidoo.register_push_token = AsyncMock()  # type: ignore[method-assign]
+        cookidoo.unregister_push_token = AsyncMock()  # type: ignore[method-assign]
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo, MagicMock(), mobile_app_id=MOBILE_APP_ID
+        )
+        await monitoring.start()
+
+        await monitoring.stop()
+
+        cookidoo.unregister_push_token.assert_awaited_once_with(TOKEN)
+        push_client.return_value.stop.assert_awaited_once()
+
+    async def test_stop_before_start_is_a_noop(self, cookidoo: Cookidoo) -> None:
+        """Stopping a receiver that never started does nothing."""
+        cookidoo.unregister_push_token = AsyncMock()  # type: ignore[method-assign]
+
+        await CookidooRemoteMonitoring(
+            cookidoo, MagicMock(), mobile_app_id=MOBILE_APP_ID
+        ).stop()
+
+        cookidoo.unregister_push_token.assert_not_awaited()
+
+    async def test_stop_survives_a_failing_unregister(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """A backend that refuses the unregister still lets the client stop."""
+        cookidoo.register_push_token = AsyncMock()  # type: ignore[method-assign]
+        cookidoo.unregister_push_token = AsyncMock(  # type: ignore[method-assign]
+            side_effect=Exception("nope")
+        )
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo, MagicMock(), mobile_app_id=MOBILE_APP_ID
+        )
+        await monitoring.start()
+
+        await monitoring.stop()
+
+        push_client.return_value.stop.assert_awaited_once()
+
+    async def test_push_is_decoded_to_a_cooking_activity(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """An incoming push reaches the callback as a typed cooking activity."""
+        cookidoo.register_push_token = AsyncMock()  # type: ignore[method-assign]
+        received: list[CookidooCookingActivity] = []
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo, received.append, mobile_app_id=MOBILE_APP_ID
+        )
+        await monitoring.start()
+
+        handler = push_client.call_args.args[0]
+        handler(COOKIDOO_TEST_PUSH_COOKING_ACTIVITY, "persistent-id")
+
+        assert len(received) == 1
+        assert received[0].state is CookidooCookState.RUNNING
+        assert received[0].recipe_name == "Purè di patate"
+        assert received[0].target_temperature == 95
+
+    async def test_push_without_cook_state_is_ignored(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """A push carrying something else does not reach the callback."""
+        cookidoo.register_push_token = AsyncMock()  # type: ignore[method-assign]
+        on_activity = MagicMock()
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo, on_activity, mobile_app_id=MOBILE_APP_ID
+        )
+        await monitoring.start()
+
+        handler = push_client.call_args.args[0]
+        handler({"data": {"unrelated": "message"}}, "persistent-id")
+
+        on_activity.assert_not_called()
+
+    async def test_credentials_are_reported(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """Rotated credentials are exposed and handed to the callback."""
+        cookidoo.register_push_token = AsyncMock()  # type: ignore[method-assign]
+        on_credentials = MagicMock()
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo,
+            MagicMock(),
+            mobile_app_id=MOBILE_APP_ID,
+            on_credentials=on_credentials,
+        )
+        await monitoring.start()
+
+        creds = credentials(TOKEN)
+        push_client.call_args.args[3](creds)
+
+        assert monitoring.credentials == creds
+        on_credentials.assert_called_once_with(creds)
+        # The token did not change, so nothing is re-registered.
+        cookidoo.register_push_token.assert_awaited_once_with(TOKEN, MOBILE_APP_ID)
+
+    async def test_rotated_token_is_reregistered(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """A token rotation resubscribes, or the pushes stop arriving."""
+        cookidoo.register_push_token = AsyncMock()  # type: ignore[method-assign]
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo, MagicMock(), mobile_app_id=MOBILE_APP_ID
+        )
+        await monitoring.start()
+
+        push_client.call_args.args[3](credentials(ROTATED_TOKEN))
+        await asyncio.sleep(0)
+
+        assert monitoring.token == ROTATED_TOKEN
+        cookidoo.register_push_token.assert_awaited_with(ROTATED_TOKEN, MOBILE_APP_ID)
+
+    async def test_failed_reregistration_is_swallowed(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """A re-registration that fails must not take the receiver down."""
+        cookidoo.register_push_token = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[None, Exception("nope")]
+        )
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo, MagicMock(), mobile_app_id=MOBILE_APP_ID
+        )
+        await monitoring.start()
+
+        push_client.call_args.args[3](credentials(ROTATED_TOKEN))
+        await asyncio.sleep(0)
+
+        assert monitoring.token == ROTATED_TOKEN
+
+    async def test_stop_cancels_a_pending_reregistration(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """Stopping mid-rotation must not leave the re-registration running."""
+        blocked = asyncio.Event()
+
+        async def _register(token: str, _mobile_app_id: str) -> None:
+            if token == ROTATED_TOKEN:
+                await blocked.wait()
+
+        cookidoo.register_push_token = AsyncMock(  # type: ignore[method-assign]
+            side_effect=_register
+        )
+        cookidoo.unregister_push_token = AsyncMock()  # type: ignore[method-assign]
+        monitoring = CookidooRemoteMonitoring(
+            cookidoo, MagicMock(), mobile_app_id=MOBILE_APP_ID
+        )
+        await monitoring.start()
+        push_client.call_args.args[3](credentials(ROTATED_TOKEN))
+        await asyncio.sleep(0)
+
+        await monitoring.stop()
+
+        push_client.return_value.stop.assert_awaited_once()
+
+    async def test_stored_credentials_are_reused(
+        self, cookidoo: Cookidoo, push_client: MagicMock
+    ) -> None:
+        """Credentials from a previous run are handed to the Firebase client."""
+        cookidoo.register_push_token = AsyncMock()  # type: ignore[method-assign]
+        stored = credentials(TOKEN)
+
+        await CookidooRemoteMonitoring(
+            cookidoo, MagicMock(), mobile_app_id=MOBILE_APP_ID, credentials=stored
+        ).start()
+
+        assert push_client.call_args.args[2] == stored


### PR DESCRIPTION
## Summary

#251 added the remote-monitoring REST surface and `cooking_activity_from_push()`, but deliberately left *receiving* the messages to the caller. In practice that means every consumer has to reimplement FCM registration and re-derive the Cookidoo app's Firebase identifiers before it can see a single cook state. There is no endpoint to poll, so without this there is no way to use the feature at all.

This adds `CookidooRemoteMonitoring`, which closes the loop:

- obtains an FCM registration token without an Android device (via `firebase-messaging`)
- registers it with `register_push_token()`
- decodes each incoming data message with `cooking_activity_from_push()` and hands a typed `CookidooCookingActivity` to a callback
- `stop()` unregisters the token and shuts the client down

```python
monitoring = CookidooRemoteMonitoring(
    cookidoo,
    lambda activity: print(activity.state, activity.recipe_name),
    mobile_app_id="a-stable-per-installation-uuid",
    credentials=stored_credentials,
    on_credentials=save_credentials,
)
await monitoring.start()
```

### Details worth a look

- **Credential persistence.** FCM credentials can be passed in and are reported back when they rotate. Reusing them keeps the same push token across restarts rather than leaving a new registration behind on every start.
- **Token rotation.** When Firebase rotates the token, the old registration stops receiving anything. The credentials callback detects the change and re-registers on a tracked task, which `stop()` cancels.
- **Payload shapes.** The appliance flattens the cook fields into the data message, but the app's `PushNotificationService` also reads them from `cookingActivity` / `remoteMonitoringInfo`, as an object or a JSON string. All three are accepted.
- **Firebase identifiers** (`FCM_PROJECT_ID`, `FCM_APP_ID`, `FCM_API_KEY`, `FCM_SENDER_ID`) are the app's public client identifiers from its google-services resources, the same class of value as the OAuth2 client id, not credentials.

### Why in the library rather than in the consumer

Receiving the state is the other half of the protocol #251 already implemented, and none of it is consumer-specific: the Firebase identifiers, the registration handshake and the payload shapes are all properties of the Cookidoo app. Leaving it out means every consumer re-derives the same identifiers and reimplements the same registration dance, and every one of them breaks the day Vorwerk rotates the project.

`firebase-messaging~=0.4` is a new runtime dependency.

### Testing

A real cook state needs a paired appliance that is mid-cook, so delivery itself cannot be asserted in CI. Everything that can rot without one can be, and `test_cookidoo_remote_monitoring` in the smoke tests does it end to end against the live backend: the app's Firebase identifiers still check in, the push connection still logs in (the new `is_connected` property), and the backend still accepts and drops the token. Decoding is covered by unit tests replaying recorded payloads, in all three shapes the app accepts.

## Verification

- `pytest`: **382 passed**, coverage **100%** maintained (`remote_monitoring.py` 103 stmts / 24 branches, fully covered)
- `ruff check` / `ruff format --check`: clean on the added files
- `mypy --strict`: clean (20 files)

Two files on `master` (`cookidoo_api/helpers.py`, `tests/responses.py`) are reformatted by ruff 0.16.6, pre-existing drift, deliberately left untouched here.
