### PR TITLE
Fix ruff format drift in helpers.py and tests/responses.py

### DIFF
--- a/cookidoo_api/helpers.py
+++ b/cookidoo_api/helpers.py
@@ -535,6 +535,7 @@ def cookidoo_custom_recipe_from_json(
     localization: CookidooLocalizationConfig | None = None,
 ) -> CookidooCustomRecipe:
     """Convert a custom recipe received from the API to a cookidoo custom recipe."""
+
     def _duration_to_seconds(value: str | int | float | None) -> int:
         if value is None:
             return 0

--- a/tests/responses.py
+++ b/tests/responses.py
@@ -438,7 +438,10 @@ COOKIDOO_TEST_RESPONSE_LIST_CUSTOM_RECIPES: Final = {
                 "yield": {"value": 6, "unitText": "portion"},
                 "ingredients": [
                     {"type": "INGREDIENT", "text": "130 g di cipolla"},
-                    {"type": "INGREDIENT", "text": "65 g di olio extravergine di oliva"},
+                    {
+                        "type": "INGREDIENT",
+                        "text": "65 g di olio extravergine di oliva",
+                    },
                 ],
                 "instructions": [
                     {"type": "STEP", "text": "Mettere nel boccale le cipolle."},


### PR DESCRIPTION
Small formatting-only fix, no behavior change.

While reviewing recent PRs, `ruff format --check` consistently flagged two pre-existing spots on `master` that had drifted out of formatter-compliance:

- `cookidoo_api/helpers.py`: missing blank line after the docstring before the nested `_duration_to_seconds` function in `cookidoo_custom_recipe_from_json`
- `tests/responses.py`: an over-long dict literal in a test fixture that the formatter wraps across multiple lines

`ruff format --check .` now reports zero drift (34 files formatted). Full test suite still passes with 100% coverage; `mypy`/`ruff check` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>