### PR TITLE
fix: serialize the OAuth2 token refresh

### DIFF
--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -111,6 +111,7 @@ class Cookidoo:
     _endpoint_overrides: dict[str, str]
     _endpoints_resolved: bool
     _endpoints_lock: asyncio.Lock
+    _token_lock: asyncio.Lock
     _refresh_token: str | None
     _expires_at: float
     _oidc: dict[str, str] | None
@@ -140,6 +141,7 @@ class Cookidoo:
         self._endpoint_overrides = {}
         self._endpoints_resolved = False
         self._endpoints_lock = asyncio.Lock()
+        self._token_lock = asyncio.Lock()
         self._refresh_token = None
         self._expires_at = 0.0
         self._oidc = None
@@ -679,12 +681,24 @@ class Cookidoo:
         self._api_headers["Authorization"] = f"Bearer {access_token}"
         self._expires_at = time.time() + expires_in
 
+    def _is_token_expiring(self) -> bool:
+        """Whether the access token is missing or within the expiry margin."""
+        return time.time() >= self._expires_at - TOKEN_EXPIRY_MARGIN_S
+
     async def _ensure_token(self) -> None:
-        """Refresh the access token if it is missing or about to expire."""
-        if not self._logged_in:
+        """Refresh the access token if it is missing or about to expire.
+
+        Guarded by a lock (checked both before and inside it) so concurrent
+        callers -- e.g. an ``asyncio.gather`` of several API methods across an
+        expiry -- await a single refresh instead of each spending the same
+        refresh token. The server may rotate that token and retire the old one,
+        so a second concurrent refresh can be rejected outright.
+        """
+        if not self._logged_in or not self._is_token_expiring():
             return
-        if time.time() >= self._expires_at - TOKEN_EXPIRY_MARGIN_S:
-            await self.refresh()
+        async with self._token_lock:
+            if self._is_token_expiring():
+                await self.refresh()
 
     @staticmethod
     def _pkce_pair() -> tuple[str, str]:

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -571,6 +571,43 @@ class TestTokenPersistenceAndRefresh:
         assert cookidoo.auth_data is not None
         assert cookidoo.auth_data.access_token == "refreshed-access-token"
 
+    async def test_concurrent_requests_refresh_once(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """Concurrent requests across an expiry share a single refresh.
+
+        The server may rotate the refresh token, retiring the one a second
+        concurrent refresh would spend, so only one may be in flight.
+        """
+        refreshes = 0
+
+        async def _token_callback(url: Any, **kwargs: Any) -> CallbackResult:
+            nonlocal refreshes
+            refreshes += 1
+            # Suspend so the other callers reach _ensure_token meanwhile
+            await asyncio.sleep(0)
+            return CallbackResult(payload=COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE)
+
+        cookidoo.apply_auth_data(CookidooAuthData("expired", "ref", 0.0))
+        mocked.get(
+            OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY, repeat=True
+        )
+        mocked.post(TOKEN_ENDPOINT, callback=_token_callback, repeat=True)
+        mocked.get(
+            "https://cookidoo.ch/community/profile/de-CH",
+            payload=COOKIDOO_TEST_RESPONSE_USER_INFO,
+            status=HTTPStatus.OK,
+            repeat=True,
+        )
+
+        await asyncio.gather(*(cookidoo.get_user_info() for _ in range(3)))
+
+        assert refreshes == 1
+
+        assert cookidoo.auth_data is not None
+        assert cookidoo.auth_data.access_token == "refreshed-access-token"
+        assert cookidoo.auth_data.refresh_token == "refreshed-refresh-token"
+
 
 class TestGetUserInfo:
     """Tests for get_user_info method."""


### PR DESCRIPTION
Follow-up to the OAuth2 work in 0.18.0.

## Problem

`_ensure_token()` checks the expiry and refreshes without any synchronisation:

```python
async def _ensure_token(self) -> None:
    if not self._logged_in:
        return
    if time.time() >= self._expires_at - TOKEN_EXPIRY_MARGIN_S:
        await self.refresh()
```

Concurrent requests that cross the expiry window therefore each start their own refresh with the *same* refresh token. Since `_apply_tokens()` accepts a rotated `refresh_token` from the response, a server that rotates and retires the previous one will reject the later refreshes, or leave the client holding a token it no longer accepts.

`_ensure_endpoints()` already guards discovery this way for exactly the same reason; the token path was simply missing the equivalent.

This is reachable from Home Assistant, whose cookidoo integration sets `PARALLEL_UPDATES = 0` on all its platforms, so a user action can overlap a coordinator poll.

## Fix

Guard the refresh with a lock, checked both before and inside it, mirroring `_ensure_endpoints()`. The expiry check moves into `_is_token_expiring()` so both checks share one definition.

## Test

`test_concurrent_requests_refresh_once` gathers three requests across an expiry and counts calls to the token endpoint.

Worth noting how it is written: an earlier version simply mocked a single token response and asserted the calls succeeded, and that passed with *and* without the lock — `aioresponses` resolves without yielding to the event loop, so the gathered calls never actually interleaved. The committed version uses an async callback that awaits `asyncio.sleep(0)` to force interleaving, and asserts the refresh count. It fails with **3 refreshes** on `master` and passes with **1** on this branch.

Full suite: 358 passed, ruff and mypy clean.