### PR TITLE
0.18.2

### DIFF
--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -1,6 +1,6 @@
 """Cookidoo API package."""
 
-__version__ = "0.18.1"
+__version__ = "0.18.2"
 
 from .cookidoo import Cookidoo
 from .exceptions import (


### PR DESCRIPTION
Version bump as requested in #262, so the token-refresh fix can be released and picked up by the Home Assistant integration.

Changes since 0.18.1:

- #261 — Fix ruff format drift in `helpers.py` and `tests/responses.py`
- #262 — Serialize the OAuth2 token refresh
- #263 — Update pydantic requirement from >=2.13.4 to >=2.13.5

Remote monitoring / device management is intentionally not in this release; it can ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XfphwxLWbVT1k2bxXGRcF