### PR TITLE
fix: normalize the failures raised during a token refresh

### DIFF
--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -506,14 +506,16 @@ class Cookidoo:
             If the OAuth2 client id or redirect uri was overridden with an
             empty value.
         CookidooRequestException
-            If the request fails.
+            If the discovery or token request fails or times out.
 
         """
         if self._refresh_token is None:
             raise CookidooAuthException("Cannot refresh: no refresh token available.")
         self._assert_oauth_client()
-        oidc = await self._discovery()
         try:
+            # Inside the try: the discovery request can fail the same way the
+            # token request can, and callers only expect CookidooException.
+            oidc = await self._discovery()
             async with self._session.post(
                 URL(oidc["token_endpoint"]),
                 data={
@@ -528,7 +530,17 @@ class Cookidoo:
                         f"Token refresh failed (status {resp.status})."
                     )
                 payload = cast(dict[str, object], await resp.json())
+        except TimeoutError as e:
+            _LOGGER.debug(
+                "Exception: Token refresh failed:\n %s", traceback.format_exc()
+            )
+            raise CookidooRequestException(
+                "Token refresh failed due to connection timeout."
+            ) from e
         except ClientError as e:
+            _LOGGER.debug(
+                "Exception: Token refresh failed:\n %s", traceback.format_exc()
+            )
             raise CookidooRequestException(
                 "Token refresh failed due to request exception."
             ) from e

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -536,6 +536,51 @@ class TestTokenPersistenceAndRefresh:
         with pytest.raises(CookidooRequestException, match="Token refresh failed"):
             await cookidoo.refresh()
 
+    async def test_refresh_timeout(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A timeout during refresh surfaces as a request exception."""
+        cookidoo.apply_auth_data(CookidooAuthData("old", "ref", 9999999999.0))
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, exception=TimeoutError())
+
+        with pytest.raises(CookidooRequestException, match="connection timeout"):
+            await cookidoo.refresh()
+
+    async def test_refresh_discovery_request_exception(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A transport error while discovering the token endpoint is normalized."""
+        cookidoo.apply_auth_data(CookidooAuthData("old", "ref", 9999999999.0))
+        mocked.get(OIDC_DISCOVERY_URL, exception=ClientError())
+
+        with pytest.raises(CookidooRequestException, match="Token refresh failed"):
+            await cookidoo.refresh()
+
+    async def test_refresh_discovery_timeout(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A timeout while discovering the token endpoint is normalized."""
+        cookidoo.apply_auth_data(CookidooAuthData("old", "ref", 9999999999.0))
+        mocked.get(OIDC_DISCOVERY_URL, exception=TimeoutError())
+
+        with pytest.raises(CookidooRequestException, match="connection timeout"):
+            await cookidoo.refresh()
+
+    async def test_auto_refresh_failure_is_normalized(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A failed implicit refresh raises a Cookidoo exception, not a raw one.
+
+        ``_ensure_token()`` runs before the request helper's own try block, so
+        anything it raises reaches the caller unchanged.
+        """
+        cookidoo.apply_auth_data(CookidooAuthData("expired", "ref", 0.0))
+        mocked.get(OIDC_DISCOVERY_URL, exception=TimeoutError())
+
+        with pytest.raises(CookidooRequestException, match="connection timeout"):
+            await cookidoo.get_user_info()
+
     async def test_no_refresh_on_valid_token(
         self, mocked: aioresponses, cookidoo: Cookidoo
     ) -> None:


### PR DESCRIPTION
`refresh()` can raise exceptions that are not `CookidooException` subclasses, so callers that catch the library's own exception hierarchy still see raw `aiohttp` / `asyncio` errors.

Two ways it leaks:

1. `oidc = await self._discovery()` sits **outside** the `try` block. `_discovery()` performs a `GET` and calls `raise_for_status()`, so a non-200 discovery response, a connection error or a timeout propagates unchanged.
2. The `try` catches only `ClientError`. A `total` timeout on the token `POST` raises `TimeoutError`, which is not a `ClientError` subclass, so it escapes too.

This is not confined to explicit `refresh()` calls. `_ensure_token()` runs *before* `_request_json()`'s own `try` block:

```python
await self._ensure_token()
merged_headers = {...}

try:
    async with self._session.request(...) as r:
```

so nothing downstream normalizes it either. Any ordinary API call made with a restored token that has expired — `get_user_info()`, `get_ingredient_items()`, … — can therefore raise a raw error at the caller.

Both `login()` and `_request_json()` already catch `TimeoutError` and `ClientError` and translate them to `CookidooRequestException`. This makes `refresh()` behave the same way: the discovery call moves inside the `try`, and `TimeoutError` is caught alongside `ClientError`. `CookidooAuthException` for a rejected refresh is unaffected — it is raised inside the `try` but is neither a `ClientError` nor a `TimeoutError`, so it still propagates as before.

Found while adopting 0.18.x in Home Assistant (home-assistant/core#181382), where the integration's `except CookidooException` handlers translate failures into user-facing errors; a leaked `aiohttp` exception surfaces as an unexpected traceback instead.

### Tests

Four regression tests, each of which fails on `master`:

- `test_refresh_timeout` — timeout on the token `POST`
- `test_refresh_discovery_request_exception` — transport error during discovery
- `test_refresh_discovery_timeout` — timeout during discovery
- `test_auto_refresh_failure_is_normalized` — the implicit refresh path, asserting `get_user_info()` on an expired token raises `CookidooRequestException`

Full suite: 362 passed. `ruff check`, `ruff format --check` and `mypy` are clean.
