### PR TITLE
feat: notify a callback whenever the OAuth2 tokens change

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See below for usage examples.
 
 ## Usage Example
 
-The API is based on the `aiohttp` library. Authentication uses the OAuth2 authorization-code flow (with PKCE) and authenticates requests with a bearer token; tokens can be persisted with `save_token`/`load_token`. A `CookieJar(unsafe=True)` is still required for the session, as the login redirect chain relies on cookies.
+The API is based on the `aiohttp` library. Authentication uses the OAuth2 authorization-code flow (with PKCE) and authenticates requests with a bearer token; tokens can be persisted with `save_token`/`load_token`, or kept in sync with a storage of your own through the `on_auth_data_update` callback, which is called whenever the tokens change -- including the refresh a request performs on its own once the access token has expired. A `CookieJar(unsafe=True)` is still required for the session, as the login redirect chain relies on cookies.
 
 Make sure to have stored your credentials in the top-level file `.env` as such, to loaded by `dotenv`. Alternatively, provide the environment variables by any other `dotenv` compatible means.
 

--- a/cookidoo_api/cookidoo.py
+++ b/cookidoo_api/cookidoo.py
@@ -116,11 +116,13 @@ class Cookidoo:
     _expires_at: float
     _oidc: dict[str, str] | None
     _rmi_links: dict[str, str] | None
+    _on_auth_data_update: Callable[[CookidooAuthData], None] | None
 
     def __init__(
         self,
         session: ClientSession,
         cfg: CookidooConfig = CookidooConfig(),
+        on_auth_data_update: Callable[[CookidooAuthData], None] | None = None,
     ) -> None:
         """Init function for Cookidoo API.
 
@@ -132,10 +134,17 @@ class Cookidoo:
             cookies during the OAuth2 login flow.
         cfg
             Cookidoo config
+        on_auth_data_update
+            Optional callback invoked with the new :class:`CookidooAuthData`
+            whenever the tokens change, i.e. after a login and after every
+            (transparent) refresh. Use it to keep a persisted copy in sync
+            without having to poll :attr:`auth_data` around every call. See
+            :attr:`on_auth_data_update`.
 
         """
         self._session = session
         self._cfg = cfg
+        self._on_auth_data_update = on_auth_data_update
         self._api_headers = DEFAULT_API_HEADERS.copy()
         self._logged_in = False
         self._endpoint_overrides = {}
@@ -404,6 +413,33 @@ class Cookidoo:
             expires_at=self._expires_at,
         )
 
+    @property
+    def on_auth_data_update(self) -> Callable[[CookidooAuthData], None] | None:
+        """The callback notified whenever the tokens change.
+
+        Called with the new :class:`CookidooAuthData` after a login and after
+        every refresh, including the transparent one a request performs when
+        the access token has expired. The server rotates the refresh token
+        along with the access token, so a consumer that persists the tokens
+        should store what the callback hands it, rather than only the result of
+        an explicit :meth:`login`.
+
+        Not called by :meth:`apply_auth_data` or :meth:`load_token`, which
+        restore tokens the consumer already holds.
+
+        Exceptions raised by the callback are caught and logged: a consumer
+        failing to store the tokens must not break the request that triggered
+        the refresh.
+        """
+        return self._on_auth_data_update
+
+    @on_auth_data_update.setter
+    def on_auth_data_update(
+        self, callback: Callable[[CookidooAuthData], None] | None
+    ) -> None:
+        """Set the callback notified whenever the tokens change."""
+        self._on_auth_data_update = callback
+
     def apply_auth_data(self, auth_data: CookidooAuthData) -> None:
         """Restore a previous login from persisted tokens (no network call).
 
@@ -478,9 +514,8 @@ class Cookidoo:
             request_id = self._extract_request_id(login_html)
             code = await self._submit_credentials(request_id, state)
 
-            # Step 5: exchange the code for tokens
+            # Step 5: exchange the code for tokens, which marks us logged in
             await self._exchange_code(oidc["token_endpoint"], code, verifier)
-            self._logged_in = True
 
         except (CookidooAuthException, CookidooParseException):
             raise
@@ -692,6 +727,23 @@ class Cookidoo:
             raise CookidooAuthException(f"Unexpected token response: {payload}") from e
         self._api_headers["Authorization"] = f"Bearer {access_token}"
         self._expires_at = time.time() + expires_in
+        # Holding tokens is what being logged in means, and `auth_data` has to
+        # be readable by the time the callback below runs.
+        self._logged_in = True
+        self._notify_auth_data_update()
+
+    def _notify_auth_data_update(self) -> None:
+        """Hand the new tokens to the consumer, if one asked to be notified."""
+        if self._on_auth_data_update is None or (auth_data := self.auth_data) is None:
+            return
+        try:
+            # Broad on purpose: this is consumer code, it can raise anything.
+            self._on_auth_data_update(auth_data)
+        except Exception:
+            _LOGGER.warning(
+                "Exception: Cannot store the updated tokens:\n%s",
+                traceback.format_exc(),
+            )
 
     def _is_token_expiring(self) -> bool:
         """Whether the access token is missing or within the expiry margin."""

--- a/example.py
+++ b/example.py
@@ -59,13 +59,18 @@ async def main():
             ),
         )
 
-        # Try to reuse a saved token, otherwise login fresh
+        # Try to reuse a saved token, otherwise login fresh. The callback keeps
+        # the file in sync afterwards: the tokens change on every login and on
+        # every refresh, including the one a request performs on its own once
+        # the access token has expired, which also rotates the refresh token.
         token_file = ".token"
+        cookidoo.on_auth_data_update = lambda _auth_data: cookidoo.save_token(
+            token_file
+        )
         try:
             cookidoo.load_token(token_file)
         except Exception:
             await cookidoo.login()
-            cookidoo.save_token(token_file)
 
         # Info
         await cookidoo.get_user_info()

--- a/tests/test_cookidoo.py
+++ b/tests/test_cookidoo.py
@@ -654,6 +654,132 @@ class TestTokenPersistenceAndRefresh:
         assert cookidoo.auth_data.refresh_token == "refreshed-refresh-token"
 
 
+class TestAuthDataUpdateCallback:
+    """Tests for the callback notified whenever the tokens change."""
+
+    async def test_called_after_login(
+        self, mocked: aioresponses, session: ClientSession
+    ) -> None:
+        """A login hands the fresh tokens to the callback."""
+        updates: list[CookidooAuthData] = []
+        cookidoo = Cookidoo(
+            session,
+            cfg=CookidooConfig(
+                client_id=TEST_CLIENT_ID, redirect_uri=TEST_REDIRECT_URI
+            ),
+            on_auth_data_update=updates.append,
+        )
+        TestLogin._mock_login_flow(mocked)
+
+        await cookidoo.login()
+
+        assert [
+            (auth_data.access_token, auth_data.refresh_token) for auth_data in updates
+        ] == [("test-access-token", "test-refresh-token")]
+
+    async def test_called_after_refresh(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """An explicit refresh hands the rotated tokens to the callback."""
+        updates: list[CookidooAuthData] = []
+
+        def _record(auth_data: CookidooAuthData) -> None:
+            updates.append(auth_data)
+
+        cookidoo.on_auth_data_update = _record
+        assert cookidoo.on_auth_data_update is _record
+        cookidoo.apply_auth_data(CookidooAuthData("old", "ref", 9999999999.0))
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE)
+
+        await cookidoo.refresh()
+
+        assert [
+            (auth_data.access_token, auth_data.refresh_token) for auth_data in updates
+        ] == [("refreshed-access-token", "refreshed-refresh-token")]
+
+    async def test_called_on_transparent_refresh(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """The refresh a request performs on its own notifies as well.
+
+        This is the case a consumer cannot see: the server rotates the refresh
+        token mid-request, so persisting only what ``login()`` returned would
+        keep a token the server has already retired.
+        """
+        updates: list[CookidooAuthData] = []
+        cookidoo.on_auth_data_update = updates.append
+        cookidoo.apply_auth_data(CookidooAuthData("expired", "ref", 0.0))
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE)
+        mocked.get(
+            "https://cookidoo.ch/community/profile/de-CH",
+            payload=COOKIDOO_TEST_RESPONSE_USER_INFO,
+            status=HTTPStatus.OK,
+        )
+
+        await cookidoo.get_user_info()
+
+        assert [
+            (auth_data.access_token, auth_data.refresh_token) for auth_data in updates
+        ] == [("refreshed-access-token", "refreshed-refresh-token")]
+
+    async def test_not_called_when_restoring_tokens(
+        self, cookidoo: Cookidoo, tmp_path: pathlib.Path
+    ) -> None:
+        """Restoring tokens the consumer already holds notifies nothing."""
+        updates: list[CookidooAuthData] = []
+        cookidoo.on_auth_data_update = updates.append
+
+        cookidoo.apply_auth_data(CookidooAuthData("acc", "ref", 9999999999.0))
+        token_file = tmp_path / "token.json"
+        cookidoo.save_token(token_file)
+        cookidoo.load_token(token_file)
+
+        assert updates == []
+
+    async def test_not_called_on_a_valid_token(
+        self, mocked: aioresponses, cookidoo: Cookidoo
+    ) -> None:
+        """A request on a still valid token changes nothing to notify about."""
+        updates: list[CookidooAuthData] = []
+        cookidoo.on_auth_data_update = updates.append
+        cookidoo.apply_auth_data(CookidooAuthData("valid", "ref", 9999999999.0))
+        mocked.get(
+            "https://cookidoo.ch/community/profile/de-CH",
+            payload=COOKIDOO_TEST_RESPONSE_USER_INFO,
+            status=HTTPStatus.OK,
+        )
+
+        await cookidoo.get_user_info()
+
+        assert updates == []
+
+    async def test_failure_does_not_break_the_request(
+        self, mocked: aioresponses, cookidoo: Cookidoo, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A consumer failing to store the tokens does not fail the request."""
+
+        def _raise(auth_data: CookidooAuthData) -> None:
+            raise RuntimeError("cannot store the tokens")
+
+        cookidoo.on_auth_data_update = _raise
+        cookidoo.apply_auth_data(CookidooAuthData("expired", "ref", 0.0))
+        mocked.get(OIDC_DISCOVERY_URL, payload=COOKIDOO_TEST_OIDC_DISCOVERY)
+        mocked.post(TOKEN_ENDPOINT, payload=COOKIDOO_TEST_REFRESHED_TOKEN_RESPONSE)
+        mocked.get(
+            "https://cookidoo.ch/community/profile/de-CH",
+            payload=COOKIDOO_TEST_RESPONSE_USER_INFO,
+            status=HTTPStatus.OK,
+        )
+
+        await cookidoo.get_user_info()
+
+        assert cookidoo.auth_data is not None
+        assert cookidoo.auth_data.access_token == "refreshed-access-token"
+        assert "Cannot store the updated tokens" in caplog.text
+
+
 class TestGetUserInfo:
     """Tests for get_user_info method."""
 


### PR DESCRIPTION
## What

Adds an optional `on_auth_data_update` callback that is called with the new `CookidooAuthData` whenever the tokens change.

## Why

A consumer that persists the tokens currently has to read `auth_data` after every call that *might* have changed them. Since 0.18.0 the access token is refreshed transparently inside `_request_json()`, and the server rotates the refresh token along with it, so there is no signal for "the tokens you stored are stale now" — storing only what `login()` produced can leave a refresh token the server has already retired.

This came up in the Home Assistant integration ([home-assistant/core#181382](https://github.com/home-assistant/core/pull/181382)), where it meant wrapping every call site that could rotate a token in a decorator that saved `auth_data` in a `finally`. With the callback the integration passes one function when it builds the client and never has to think about tokens at either call site again — which is where the reviewer thought the logic belonged in the first place.

## How

- `Cookidoo(session, cfg, on_auth_data_update=...)`, also settable later through the `on_auth_data_update` property.
- Called from `_apply_tokens()`, so it fires on a login, on an explicit `refresh()` and on the implicit refresh a request performs.
- Not called by `apply_auth_data()` / `load_token()` — those restore tokens the consumer already holds.
- Exceptions from the callback are caught and logged: a consumer failing to store the tokens must not fail the request that happened to cross the expiry.
- `_apply_tokens()` now also sets `_logged_in`, so `auth_data` is readable by the time the callback runs during the initial login (`login()` used to set it one line later).

Backwards compatible: the parameter is optional and nothing changes when it is not passed.

`example.py` now uses it to keep `.token` in sync, which the previous version did not do — it only wrote the file at login, so a rotated refresh token was silently dropped.

## Tests

New `TestAuthDataUpdateCallback`: notification after a login, after an explicit refresh and after a transparent one; no notification when restoring tokens or when the access token is still valid; and a raising callback that neither breaks the request nor loses the new tokens.

`pytest`, `ruff check`, `ruff format --check` and `mypy` all pass locally.
