### PR TITLE
0.18.4

### DIFF
--- a/cookidoo_api/__init__.py
+++ b/cookidoo_api/__init__.py
@@ -1,6 +1,6 @@
 """Cookidoo API package."""
 
-__version__ = "0.18.3"
+__version__ = "0.18.4"
 
 from .cookidoo import Cookidoo
 from .exceptions import (


### PR DESCRIPTION
Bumps `__version__` to 0.18.4 so #267 (`on_auth_data_update`) can be tagged and published.

home-assistant/core#181382 adopts the callback — it is the change [erwindouna asked for in review](https://github.com/home-assistant/core/pull/181382#discussion_r3976371899), moving the token persistence out of the integration and into the library — so that PR's manifest pins `cookidoo-api==0.18.4` and it cannot leave draft until the release is on PyPI.

Same shape as #264: a single `__version__` bump, nothing else. @miaucl could you tag and publish it once this is in?